### PR TITLE
Add test for spectrum autorange, some logic fixes

### DIFF
--- a/core/source/api/opencmiss/zinc/scene.hpp
+++ b/core/source/api/opencmiss/zinc/scene.hpp
@@ -296,7 +296,7 @@ inline Scene Graphics::getScene()
 	return Scene(cmzn_graphics_get_scene(id));
 }
 
-inline int Spectrum::autorange(Scene &scene, Scenefilter &scenefilter)
+inline int Spectrum::autorange(const Scene &scene, const Scenefilter &scenefilter)
 {
 	return cmzn_spectrum_autorange(id, scene.getId(), scenefilter.getId());
 }

--- a/core/source/api/opencmiss/zinc/spectrum.h
+++ b/core/source/api/opencmiss/zinc/spectrum.h
@@ -411,52 +411,59 @@ ZINC_API int cmzn_spectrumcomponent_set_range_maximum(
 	cmzn_spectrumcomponent_id component,	double value);
 
 /**
- * Get the normalised minimum value for the colour type of this spectrum
- * component. The range of colour displayed by this spectrum ranges from
- * minimum value of colour to the maximum value of colour
+ * Get the colour value mapped to the minimum spectrum component data range.
+ * This is a normalised value from 0.0 to 1.0.
  *
- * @param component  The handle of the spectrum component.
- * @return  minimum value of colour on success.
+ * @param component  The handle to the spectrum component.
+ * @return  Minimum colour value from 0.0 to 1.0, or 0.0 if invalid component.
  */
 ZINC_API double cmzn_spectrumcomponent_get_colour_minimum(
 	cmzn_spectrumcomponent_id component);
 
 /**
- * Set the normalised minimum value for the colour type of this spectrum
- * component. The range of colour displayed by this spectrum ranges from
- * minimum value of colour to the miximum value of colour
- * Changing this value does not affect COLOUR_MAPPING_TYPE_BANDED, use
- * cmzn_spectrumcomponent_set_number_of_bands to set the number of bands.
+ * Set the colour value mapped to the minimum spectrum component data range.
+ * This is a normalised value from 0.0 to 1.0, mapping to a position in the
+ * colour map. For simple colour mappings red, green, blue and alpha, this
+ * gives the exact colour component value at the minimum data range, which is
+ * interpolated to the maximum colour at the maximum data range.
+ * Note that setting 'reverse' colours reverses the association of colour range
+ * and data range; it is recommended the colour minimum and maximum be swapped
+ * instead of using reverse.
+ * @see cmzn_spectrumcomponent_set_colour_reverse
+ * Changing this value does not affect COLOUR_MAPPING_TYPE_BANDED which is
+ * only affected by the number and ratio of bands.
  *
- * @param component  The handle of the spectrum component.
- * @value  the minimum colour value to be set
- *
+ * @param component  The handle to the spectrum component.
+ * @value  The minimum colour value to set, from 0.0 to 1.0.
  * @return  CMZN_OK on success, otherwise CMZN_ERROR_ARGUMENT.
  */
 ZINC_API int cmzn_spectrumcomponent_set_colour_minimum(
 	cmzn_spectrumcomponent_id component, double value);
 
 /**
- * Get the normalised maximum value for the colour type of this spectrum
- * component. The range of colour displayed by this spectrum ranges from
- * minimum value of colour to the maximum value of colour
+ * Get the colour value mapped to the maximum spectrum component data range.
+ * This is a normalised value from 0.0 to 1.0.
  *
- * @param component  The handle of the spectrum component.
- * @return  maximum value of colour on success.
+ * @param component  The handle to the spectrum component.
+ * @return  Maximum colour value from 0.0 to 1.0, or 0.0 if invalid component.
  */
 ZINC_API double cmzn_spectrumcomponent_get_colour_maximum(
 	cmzn_spectrumcomponent_id component);
 
 /**
- * Set the normalised maximum value for the colour type of this spectrum
- * component. The range of colour displayed by this spectrum ranges from
- * minimum value of colour to the miximum value of colour.
- * Changing this value does not affect COLOUR_MAPPING_TYPE_BANDED, use
- * cmzn_spectrumcomponent_set_number_of_bands to set the number of bands.
+ * Set the colour value mapped to the maximum spectrum component data range.
+ * This is a normalised value from 0.0 to 1.0, mapping to a position in the
+ * colour map. For simple colour mappings red, green, blue and alpha, this
+ * gives the exact colour component value at the maximum data range, which is
+ * interpolated to the minimum colour at the minimum data range.
+ * Note that setting 'reverse' colours reverses the association of colour range
+ * and data range; it is recommended the colour minimum and maximum be swapped
+ * instead of using reverse.
+ * Changing this value does not affect COLOUR_MAPPING_TYPE_BANDED which is
+ * only affected by the number and ratio of bands.
  *
- * @param component  The handle of the spectrum component.
- * @value  the maximum colour value to be set
- *
+ * @param component  The handle to the spectrum component.
+ * @value  The maximum colour value to set, from 0.0 to 1.0.
  * @return  CMZN_OK on success, otherwise CMZN_ERROR_ARGUMENT.
  */
 ZINC_API int cmzn_spectrumcomponent_set_colour_maximum(
@@ -560,7 +567,7 @@ ZINC_API int cmzn_spectrumcomponent_set_active(
 
 /**
  * Get the reverse flag of a spectrum component, reverse spectrum component will
- * have the colour rendered reversely
+ * have the colour rendered reversely.
  *
  * @param component  Handle to the zinc spectrum component.
  * @return  true if spectrum component is reverse, false if
@@ -570,8 +577,11 @@ ZINC_API bool cmzn_spectrumcomponent_is_colour_reverse(
 	cmzn_spectrumcomponent_id component);
 
 /**
- * Set the reverse flag of a spectrum component, reverse spectrum component will
- * have the colour rendered reversely
+ * Set the reverse flag of a spectrum component, which if set maps the colour
+ * maximum to the data range minimum, and the colour minimum to the data range
+ * maximum. This is primarily intended to reverse the rainbow colour map.
+ * With most colour maps, swapping the colour minimum and maximum values is
+ * easier to explain and achieves the same result.
  *
  * @param component  Handle to the zinc spectrum component.
  * @param reverse  Value to be set to the zinc spectrum component.

--- a/core/source/api/opencmiss/zinc/spectrum.hpp
+++ b/core/source/api/opencmiss/zinc/spectrum.hpp
@@ -429,7 +429,7 @@ public:
 		return cmzn_spectrum_set_material_overwrite(id, overwrite);
 	}
 
-	inline int autorange(Scene &scene, Scenefilter &scenefilter);
+	inline int autorange(const Scene &scene, const Scenefilter &scenefilter);
 
 };
 

--- a/core/source/graphics/spectrum.cpp
+++ b/core/source/graphics/spectrum.cpp
@@ -800,19 +800,11 @@ some predetermined simple types.
 					CMZN_SPECTRUMCOMPONENT_COLOUR_MAPPING_TYPE_RAINBOW);
 				cmzn_spectrumcomponent_set_extend_above(component,true);
 				cmzn_spectrumcomponent_set_extend_below(component, true);
-				switch (type)
+				if (type == BLUE_TO_RED_SPECTRUM)
 				{
-					case RED_TO_BLUE_SPECTRUM:
-					{
-						cmzn_spectrumcomponent_set_colour_reverse(component,false);
-					} break;
-					case BLUE_TO_RED_SPECTRUM:
-					{
-						cmzn_spectrumcomponent_set_colour_reverse(component, true);
-					} break;
-					default:
-					{
-					} break;
+					// reverse mapped colour values; avoiding using reverse mode as it's confusing
+					cmzn_spectrumcomponent_set_colour_minimum(component, 1.0);
+					cmzn_spectrumcomponent_set_colour_maximum(component, 0.0);
 				}
 				cmzn_spectrumcomponent_destroy(&component);
 			} break;

--- a/core/source/graphics/spectrum.cpp
+++ b/core/source/graphics/spectrum.cpp
@@ -2842,7 +2842,7 @@ void cmzn_spectrum_get_components_range(cmzn_spectrum_id spectrum, int valuesCou
 				{
 					if (!fixed_maximum && (maximum[current_index] < currentMaxValue))
 						maximum[current_index] = currentMaxValue;
-					if (!fixed_minimum && (minimum[current_index] < currentMinValue))
+					if (!fixed_minimum && (minimum[current_index] > currentMinValue))
 						minimum[current_index] = currentMinValue;
 				}
 			}
@@ -2869,18 +2869,22 @@ void cmzn_spectrum_rerange_components(cmzn_spectrum_id spectrum, int maxRanges,
 				double oldComponentRange =  oldMaxValues[dataComponent-1] - oldMinValues[dataComponent-1];
 				double thisMinimum = cmzn_spectrumcomponent_get_range_minimum(component);
 				double thisMaximum = cmzn_spectrumcomponent_get_range_maximum(component);
-				double minimumRatio = (thisMinimum - oldMinValues[dataComponent - 1]) / oldComponentRange;
-				double maximumRatio = (thisMaximum - oldMinValues[dataComponent - 1]) / oldComponentRange;
+				double minimumRatio = 0.0;
+				double maximumRatio = 1.0;
+				if (oldComponentRange != 0.0)
+				{
+					minimumRatio = (thisMinimum - oldMinValues[dataComponent - 1]) / oldComponentRange;
+					maximumRatio = (thisMaximum - oldMinValues[dataComponent - 1]) / oldComponentRange;
+				}
 				double dataMinimum = minimum[dataComponent - 1];
 				double dataMaximum = maximum[dataComponent - 1];
-				double newComponentRange = dataMaximum - dataMinimum;
-				double newComponentMinimum = dataMinimum + minimumRatio*newComponentRange;
-				double newComponentMaximum = dataMinimum + maximumRatio*newComponentRange;
+				double newComponentMinimum = dataMinimum*(1.0 - minimumRatio) + dataMaximum*minimumRatio;
+				double newComponentMaximum = dataMinimum*(1.0 - maximumRatio) + dataMaximum*maximumRatio;
 				if (!cmzn_spectrumcomponent_is_fix_minimum(component))
 					cmzn_spectrumcomponent_set_range_minimum(component, newComponentMinimum);
 				if (!cmzn_spectrumcomponent_is_fix_maximum(component))
 					cmzn_spectrumcomponent_set_range_maximum(component, newComponentMaximum);
-			 }
+			}
 			cmzn_spectrumcomponent_id next_component =
 				cmzn_spectrum_get_next_spectrumcomponent(spectrum, component);
 			cmzn_spectrumcomponent_destroy(&component);

--- a/core/source/graphics/spectrum_component.cpp
+++ b/core/source/graphics/spectrum_component.cpp
@@ -921,10 +921,6 @@ int cmzn_spectrumcomponent_set_colour_minimum(
 		if (value != component->min_value)
 		{
 			component->min_value = value;
-			if (value > component->max_value)
-			{
-				component->max_value = value;
-			}
 			cmzn_spectrumcomponent_changed(component);
 		}
 		return CMZN_OK;
@@ -952,10 +948,6 @@ int cmzn_spectrumcomponent_set_colour_maximum(
 		if (value != component->max_value)
 		{
 			component->max_value = value;
-			if (value < component->min_value)
-			{
-				component->min_value = value;
-			}
 			cmzn_spectrumcomponent_changed(component);
 		}
 		return CMZN_OK;

--- a/tests/spectrum/zinctestsetupcpp.hpp
+++ b/tests/spectrum/zinctestsetupcpp.hpp
@@ -11,7 +11,7 @@
 
 #include <gtest/gtest.h>
 
-#include <opencmiss/zinc/status.h>
+#include <opencmiss/zinc/status.hpp>
 #include <opencmiss/zinc/context.hpp>
 #include <opencmiss/zinc/region.hpp>
 #include <opencmiss/zinc/fieldmodule.hpp>
@@ -39,7 +39,7 @@ public:
 		scene = root_region.getScene();
 		EXPECT_TRUE(fm.isValid());
 		EXPECT_TRUE(glyphmodule.isValid());
-		EXPECT_EQ(CMZN_OK, glyphmodule.defineStandardGlyphs());
+		EXPECT_EQ(OK, glyphmodule.defineStandardGlyphs());
 		EXPECT_TRUE(scene.isValid());
 	}
 


### PR DESCRIPTION
Test spectrum autorange API with multiple components and fixed minimum/maximum. Fix erroneous comparison operator and handling of zero ranges which could cause division by zero. Add const qualifiers to C++ API method arguments.
