### PR TITLE
Fix removing and reordering graphics in editor copy scene

### DIFF
--- a/core/source/graphics/graphics.cpp
+++ b/core/source/graphics/graphics.cpp
@@ -5022,13 +5022,6 @@ Must call cmzn_graphics_to_graphics_object afterwards to complete.
 	return (return_code);
 } /* cmzn_graphics_selected_element_points_change */
 
-struct cmzn_scene *cmzn_graphics_get_scene_private(struct cmzn_graphics *graphics)
-{
-	if (graphics)
-		return graphics->scene;
-	return NULL;
-}
-
 int cmzn_graphics_set_scene_private(struct cmzn_graphics *graphics,
 	struct cmzn_scene *scene)
 {

--- a/core/source/graphics/graphics.h
+++ b/core/source/graphics/graphics.h
@@ -193,6 +193,12 @@ finite element group scene.
 		return (0 != this->isoscalar_field)
 			&& Computed_field_has_multiple_times(this->isoscalar_field);
 	}
+
+	/** @return  Non-accessed scene. Can be NULL if editor copy. */
+	cmzn_scene *getScene() const
+	{
+		return this->scene;
+	}
 };
 
 struct cmzn_graphics_module;
@@ -660,8 +666,6 @@ int cmzn_graphics_get_overlay_order(struct cmzn_graphics *graphics);
  * @return Return 1 if successfully detach fields from graphics otherwise 0.
  */
 int cmzn_graphics_detach_fields(struct cmzn_graphics *graphics, void *dummy_void);
-
-struct cmzn_scene *cmzn_graphics_get_scene_private(struct cmzn_graphics *graphics);
 
 int cmzn_graphics_set_scene_private(struct cmzn_graphics *graphics,
 	struct cmzn_scene *scene);

--- a/core/source/graphics/render_gl.cpp
+++ b/core/source/graphics/render_gl.cpp
@@ -799,8 +799,7 @@ public:
 				cmzn_texture_get_texture_coordinate_sizes(texture, 3, textureSizes);
 			}
 			char *graphics_name = cmzn_graphics_get_name_internal(graphics);
-			struct cmzn_scene *scene = cmzn_graphics_get_scene_private(graphics);
-			struct cmzn_region *region = cmzn_scene_get_region_internal(scene);
+			struct cmzn_region *region = cmzn_scene_get_region_internal(graphics->getScene());
 			char *group_name = 0;
 			cmzn_field_id groupField = 0;
 			groupField = cmzn_graphics_get_subgroup_field(graphics);

--- a/core/source/graphics/scene.cpp
+++ b/core/source/graphics/scene.cpp
@@ -938,7 +938,7 @@ int cmzn_scene_add_graphics(struct cmzn_scene *scene,
 	struct cmzn_graphics *graphics,int position)
 {
 	int return_code;
-	if (scene && graphics && (NULL == cmzn_graphics_get_scene_private(graphics)))
+	if (scene && graphics && (graphics->getScene() == 0))
 	{
 		return_code=cmzn_graphics_add_to_list(graphics,position,
 			scene->list_of_graphics);
@@ -957,7 +957,8 @@ int cmzn_scene_add_graphics(struct cmzn_scene *scene,
 int cmzn_scene_remove_graphics(struct cmzn_scene *scene,
 	struct cmzn_graphics *graphics)
 {
-	if (scene && graphics && (scene == cmzn_graphics_get_scene_private(graphics)))
+	if (scene && graphics && ((graphics->getScene() == scene) ||
+		(scene->editorCopy && (graphics->getScene() == 0))))
 	{
 		cmzn_graphics_set_scene_private(graphics, NULL);
 		cmzn_graphics_remove_from_list(graphics, scene->list_of_graphics);
@@ -1693,7 +1694,7 @@ int cmzn_region_modify_scene(struct cmzn_region *region,
 					}
 					/* modify same_graphics to match new ones */
 					return_code = 1;
-					if (!cmzn_graphics_get_scene_private(same_graphics))
+					if (same_graphics->getScene() == 0)
 						cmzn_graphics_set_scene_private(same_graphics, scene);
 					DEACCESS(cmzn_graphics)(&same_graphics);
 				}
@@ -2794,10 +2795,9 @@ int cmzn_scene_move_graphics_before(cmzn_scene_id scene,
 	cmzn_graphics_id graphics, cmzn_graphics_id ref_graphics)
 {
 	int return_code = CMZN_ERROR_GENERAL;
-	if (scene && graphics &&
-		(cmzn_graphics_get_scene_private(graphics) == scene) && ((0 == ref_graphics) ||
-			(cmzn_graphics_get_scene_private(graphics) ==
-				cmzn_graphics_get_scene_private(ref_graphics))))
+	if (scene && graphics
+		&& ((graphics->getScene() == scene) || (scene->editorCopy && (graphics->getScene() == 0)))
+		&& ((0 == ref_graphics) || (graphics->getScene() == (ref_graphics->getScene()))))
 	{
 		cmzn_graphics_id current_graphics = ACCESS(cmzn_graphics)(graphics);
 		const int position = cmzn_scene_get_graphics_position(scene, ref_graphics);


### PR DESCRIPTION
Cmgui uses an editor copy of a scene, and in that state its graphics do not maintain pointers to the scene. Too stringent argument checking on some APIs prevented Cmgui from removing or reordering graphics in the scene editor, which this pull request fixes.
