### PR TITLE
Allow semicolon in EX scale factor set name

### DIFF
--- a/core/source/graphics/shader_program.cpp
+++ b/core/source/graphics/shader_program.cpp
@@ -271,11 +271,11 @@ struct cmzn_shaderprogram_compare_name
 
 typedef cmzn_set<cmzn_shaderprogram_id ,cmzn_shaderprogram_compare_name> cmzn_set_cmzn_shaderprogram;
 
-FULL_DECLARE_MANAGER_TYPE_WITH_OWNER(cmzn_shaderprogram, cmzn_shadermodule, struct cmzn_shaderprogram_change_detail *);
+FULL_DECLARE_MANAGER_TYPE_WITH_OWNER(cmzn_shaderprogram, cmzn_shadermodule, class cmzn_shaderprogram_change_detail *);
 
 DECLARE_DEFAULT_MANAGER_UPDATE_DEPENDENCIES_FUNCTION(cmzn_shaderprogram);
 
-inline struct cmzn_shaderprogram_change_detail *MANAGER_EXTRACT_CHANGE_DETAIL(cmzn_shaderprogram)(
+inline cmzn_shaderprogram_change_detail *MANAGER_EXTRACT_CHANGE_DETAIL(cmzn_shaderprogram)(
 		cmzn_shaderprogram_id program)
 {
 	return program->extractChangeDetail();

--- a/core/source/graphics/shader_program.hpp
+++ b/core/source/graphics/shader_program.hpp
@@ -36,7 +36,7 @@ public:
 
 };
 
-struct Render_graphics_opengl;
+class Render_graphics_opengl;
 struct Texture;
 
 enum cmzn_shaderprogram_type

--- a/core/source/graphics/threejs_export.cpp
+++ b/core/source/graphics/threejs_export.cpp
@@ -1040,7 +1040,7 @@ void Threejs_export_glyph::exportGlyphsTransformation(struct GT_object *object, 
 				{
 					if (time_step != 0)
 						morphVerticesExported = true;
-					for (int k = 0; k < position_values_per_vertex; k++)
+					for (unsigned int k = 0; k < position_values_per_vertex; k++)
 					{
 						positions_json[temp_string].append(position[k]);
 						axis1_json[temp_string].append(axis1[k]);


### PR DESCRIPTION
Addresses problem reading example seeded_streamlines cavity model mentioned in Issue #145.
Fix render compilation warnings.
