### PR TITLE
Zincjs empty export bug fix

### DIFF
--- a/src/api/opencmiss/zinc/scene.h
+++ b/src/api/opencmiss/zinc/scene.h
@@ -580,8 +580,8 @@ ZINC_API cmzn_scenepicker_id cmzn_scene_create_scenepicker(cmzn_scene_id scene);
 
 /**
  * Writes graphics data in scene to stream resource objects described in the stream
- * information object. Stream resources memory may return as a null ptr in some
- * cases.
+ * information object. Buffer in stream resources memory may return as a null ptr 
+ * in some cases and the callers should check against it.
  * @see cmzn_scene_create_streaminformation_scene
  *
  * @param scene  The scene to be written out.

--- a/src/api/opencmiss/zinc/scene.h
+++ b/src/api/opencmiss/zinc/scene.h
@@ -580,7 +580,8 @@ ZINC_API cmzn_scenepicker_id cmzn_scene_create_scenepicker(cmzn_scene_id scene);
 
 /**
  * Writes graphics data in scene to stream resource objects described in the stream
- * information object.
+ * information object. Stream resources memory may return as a null ptr in some
+ * cases.
  * @see cmzn_scene_create_streaminformation_scene
  *
  * @param scene  The scene to be written out.

--- a/src/api/opencmiss/zinc/streamscene.h
+++ b/src/api/opencmiss/zinc/streamscene.h
@@ -219,7 +219,10 @@ ZINC_API int cmzn_streaminformation_scene_set_initial_time(
 	cmzn_streaminformation_scene_id streaminformation, double initialTime);
 
 /**
- * Get the the number of resources required to fully export the scene.
+ * Get the the number of resources required to fully export 
+ * the scene. Some of the resource outputs may not be used but 
+ * they are required in order to fully support the exports.
+ * 
  * Some formats require more than 1 resource to fully export the scene,
  * use this function to find the number of resources required.
  *

--- a/src/api/opencmiss/zinc/streamscene.h
+++ b/src/api/opencmiss/zinc/streamscene.h
@@ -219,9 +219,9 @@ ZINC_API int cmzn_streaminformation_scene_set_initial_time(
 	cmzn_streaminformation_scene_id streaminformation, double initialTime);
 
 /**
- * Get the the number of resources required to fully export 
- * the scene. Some of the resource outputs may not be used but 
- * they are required in order to fully support the exports.
+ * Get the number of resources required to fully export 
+ * the scene. Some of the resource outputs may not be used in some 
+ * cases.
  * 
  * Some formats require more than 1 resource to fully export the scene,
  * use this function to find the number of resources required.

--- a/src/graphics/render_gl.cpp
+++ b/src/graphics/render_gl.cpp
@@ -640,7 +640,7 @@ public:
 	/* this will generate the meta data string */
 	std::string get_metadata_string()
 	{
-		Json::Value root;
+		Json::Value root = Json::arrayValue;
 		int i = 1;
 		for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
 			export_iter != exports_map.end(); export_iter++)

--- a/src/graphics/render_gl.cpp
+++ b/src/graphics/render_gl.cpp
@@ -645,75 +645,78 @@ public:
 		for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
 			export_iter != exports_map.end(); export_iter++)
 		{
-			Json::Value graphics_json;
-			graphics_json["MorphVertices"] = export_iter->second->getMorphVerticesExported();
-			graphics_json["MorphColours"] = export_iter->second->getMorphColoursExported();
-			graphics_json["MorphNormals"] = export_iter->second->getMorphNormalsExported();
-			if (isInline)
+			if (export_iter->second->isValid())
 			{
-				graphics_json["Inline"]["URL"]= export_iter->second->getExportJson();
-			}
-			else
-			{
-				if (numberOfResources > i)
-				{
-					graphics_json["URL"] = filenames[i];
-				}
-				else
-				{
-					char temp[40];
-					sprintf(temp, "temp_%d.json", i+1);
-					graphics_json["URL"] = temp;
-				}
-			}
-			const char *group_name = export_iter->second->getGroupName();
-			if (group_name)
-				graphics_json["GroupName"] = group_name;
-			const char *region_path = export_iter->second->getRegionPath();
-			if (region_path)
-				graphics_json["RegionPath"] = region_path;
-
-			Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(export_iter->second);
-			Threejs_export_line *line_export = dynamic_cast<Threejs_export_line*>(export_iter->second);
-			Threejs_export_point *point_export = dynamic_cast<Threejs_export_point*>(export_iter->second);
-			if (glyph_export)
-			{
-				graphics_json["Type"]="Glyph";
-				i++;
+				Json::Value graphics_json;
+				graphics_json["MorphVertices"] = export_iter->second->getMorphVerticesExported();
+				graphics_json["MorphColours"] = export_iter->second->getMorphColoursExported();
+				graphics_json["MorphNormals"] = export_iter->second->getMorphNormalsExported();
 				if (isInline)
 				{
-					graphics_json["Inline"]["GlyphGeometriesURL"] = glyph_export->getGlyphTransformationExportJson();
+					graphics_json["Inline"]["URL"]= export_iter->second->getExportJson();
 				}
 				else
 				{
 					if (numberOfResources > i)
 					{
-						graphics_json["GlyphGeometriesURL"] = filenames[i];
-						glyph_export->setGlyphGeometriesURLName(filenames[i]);
+						graphics_json["URL"] = filenames[i];
 					}
 					else
 					{
 						char temp[40];
 						sprintf(temp, "temp_%d.json", i+1);
-						graphics_json["GlyphGeometriesURL"] = temp;
-						glyph_export->setGlyphGeometriesURLName(temp);
+						graphics_json["URL"] = temp;
 					}
 				}
+				const char *group_name = export_iter->second->getGroupName();
+				if (group_name)
+					graphics_json["GroupName"] = group_name;
+				const char *region_path = export_iter->second->getRegionPath();
+				if (region_path)
+					graphics_json["RegionPath"] = region_path;
+
+				Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(export_iter->second);
+				Threejs_export_line *line_export = dynamic_cast<Threejs_export_line*>(export_iter->second);
+				Threejs_export_point *point_export = dynamic_cast<Threejs_export_point*>(export_iter->second);
+				if (glyph_export)
+				{
+					graphics_json["Type"]="Glyph";
+					i++;
+					if (isInline)
+					{
+						graphics_json["Inline"]["GlyphGeometriesURL"] = glyph_export->getGlyphTransformationExportJson();
+					}
+					else
+					{
+						if (numberOfResources > i)
+						{
+							graphics_json["GlyphGeometriesURL"] = filenames[i];
+							glyph_export->setGlyphGeometriesURLName(filenames[i]);
+						}
+						else
+						{
+							char temp[40];
+							sprintf(temp, "temp_%d.json", i+1);
+							graphics_json["GlyphGeometriesURL"] = temp;
+							glyph_export->setGlyphGeometriesURLName(temp);
+						}
+					}
+				}
+				else if (line_export)
+				{
+					graphics_json["Type"]="Lines";
+				}
+				else if (point_export)
+				{
+					graphics_json["Type"]="Points";
+				}
+				else
+				{
+					graphics_json["Type"]="Surfaces";
+				}
+				i++;
+				root.append(graphics_json);
 			}
-			else if (line_export)
-			{
-				graphics_json["Type"]="Lines";
-			}
-			else if (point_export)
-			{
-				graphics_json["Type"]="Points";
-			}
-			else
-			{
-				graphics_json["Type"]="Surfaces";
-			}
-			i++;
-			root.append(graphics_json);
 		}
 
 		return Json::StyledWriter().write(root);

--- a/src/graphics/render_gl.cpp
+++ b/src/graphics/render_gl.cpp
@@ -631,9 +631,8 @@ public:
 					size++;
 			}
 		}
-		//Also a file providing metafile, only when there is graphics to be exported
-		if (size > 0)
-			size++;
+		//Also a file providing metafile.
+		size++;
 		return size;
 	}
 

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -683,9 +683,15 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 			{
 				if (time_step == 0)
 				{
-					writeVertexBuffer("vertices",
-						position_vertex_buffer, position_values_per_vertex,
-						position_vertex_count);
+					if (position_vertex_count > 0) {
+						writeVertexBuffer("vertices",
+							position_vertex_buffer, position_values_per_vertex,
+							position_vertex_count);
+					}
+					else
+					{
+						this->isEmpty = 1;
+					}
 				}
 				if (number_of_time_steps > 1)
 				{
@@ -699,118 +705,121 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 				}
 			}
 
-			/* export the colour buffer */
-			if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
+			if (this->isEmpty == 0)
 			{
-				/* this case export the colour */
-				unsigned int colour_values_per_vertex, colour_vertex_count;
-				GLfloat *colour_buffer = (GLfloat *)NULL;
-				if (Graphics_object_create_colour_buffer_from_data(object,
-					&colour_buffer,
-					&colour_values_per_vertex, &colour_vertex_count)
-					&& (colour_vertex_count == position_vertex_count))
+				/* export the colour buffer */
+				if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
 				{
-					int *hex_colours = new int[colour_vertex_count];
-					GLfloat *colours = colour_buffer;
-					for (unsigned int i = 0; i < colour_vertex_count; i++)
+					/* this case export the colour */
+					unsigned int colour_values_per_vertex, colour_vertex_count;
+					GLfloat *colour_buffer = (GLfloat *)NULL;
+					if (Graphics_object_create_colour_buffer_from_data(object,
+						&colour_buffer,
+						&colour_values_per_vertex, &colour_vertex_count)
+						&& (colour_vertex_count == position_vertex_count))
 					{
-						hex_colours[i] = rgb_to_hex(colours[0], colours[1], colours[2]);
-						colours += colour_values_per_vertex;
+						int *hex_colours = new int[colour_vertex_count];
+						GLfloat *colours = colour_buffer;
+						for (unsigned int i = 0; i < colour_vertex_count; i++)
+						{
+							hex_colours[i] = rgb_to_hex(colours[0], colours[1], colours[2]);
+							colours += colour_values_per_vertex;
+						}
+						if (time_step == 0)
+						{
+							typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
+							writeIntegerBuffer("colors",
+								hex_colours, 1, colour_vertex_count);
+						}
+						if (number_of_time_steps > 1)
+						{
+							if (morphColours)
+							{
+								morphColoursExported = true;
+								writeMorphIntegerBuffer("colors", &colorsMorphString,
+									hex_colours, 1, colour_vertex_count, time_step);
+							}
+						}
+						delete[] hex_colours;
+						if (colour_buffer)
+						{
+							DEALLOCATE(colour_buffer);
+						}
 					}
+				}
+				else if ((mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_VERTEX_VALUE) ||
+					(mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE))
+				{
+					/* this case export the field data directly */
+					GLfloat *data_buffer = NULL;
+					unsigned int data_values_per_vertex, data_vertex_count;
+					if (object->vertex_array->get_float_vertex_buffer(
+						GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_DATA,
+						&data_buffer, &data_values_per_vertex, &data_vertex_count))
+					{
+						if (time_step == 0)
+						{
+							if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE)
+							{
+								typebitmask |= THREEJS_TYPE_FACE_COLOR;
+							}
+							else
+							{
+								typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
+							}
+							writeSpecialDataBuffer(object, data_buffer, data_values_per_vertex,
+								data_vertex_count);
+						}
+					}
+				}
+
+				/* export the normal buffer */
+				GLfloat *normal_buffer = NULL;
+				unsigned int normal_values_per_vertex, normal_vertex_count;
+				if (object->vertex_array->get_float_vertex_buffer(
+					GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_NORMAL,
+					&normal_buffer, &normal_values_per_vertex, &normal_vertex_count)
+					&& (3 == normal_values_per_vertex) && (normal_vertex_count > 0))
+				{
 					if (time_step == 0)
 					{
-						typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
-						writeIntegerBuffer("colors",
-							hex_colours, 1, colour_vertex_count);
+						typebitmask |= THREEJS_TYPE_VERTEX_NORMAL;
+						writeVertexBuffer("normals",
+							normal_buffer, normal_values_per_vertex,
+							normal_vertex_count);
 					}
 					if (number_of_time_steps > 1)
 					{
-						if (morphColours)
+						if (morphNormals)
 						{
-							morphColoursExported = true;
-							writeMorphIntegerBuffer("colors", &colorsMorphString,
-								hex_colours, 1, colour_vertex_count, time_step);
+							morphNormalsExported = true;
+							writeMorphVertexBuffer("normals", &normalMorphString,
+								normal_buffer, normal_values_per_vertex,
+								normal_vertex_count, time_step);
 						}
 					}
-					delete[] hex_colours;
-					if (colour_buffer)
-					{
-						DEALLOCATE(colour_buffer);
-					}
 				}
-			}
-			else if ((mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_VERTEX_VALUE) ||
-				(mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE))
-			{
-				/* this case export the field data directly */
-				GLfloat *data_buffer = NULL;
-				unsigned int data_values_per_vertex, data_vertex_count;
+
+				/* export the texture coordinates buffer */
+				GLfloat *texture_coordinate0_buffer = NULL;
+				unsigned int texture_coordinate0_values_per_vertex,
+				texture_coordinate0_vertex_count;
 				if (object->vertex_array->get_float_vertex_buffer(
-					GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_DATA,
-					&data_buffer, &data_values_per_vertex, &data_vertex_count))
+					GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_TEXTURE_COORDINATE_ZERO,
+					&texture_coordinate0_buffer, &texture_coordinate0_values_per_vertex,
+					&texture_coordinate0_vertex_count) && (texture_coordinate0_vertex_count > 0))
 				{
 					if (time_step == 0)
 					{
-						if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE)
-						{
-							typebitmask |= THREEJS_TYPE_FACE_COLOR;
-						}
-						else
-						{
-							typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
-						}
-						writeSpecialDataBuffer(object, data_buffer, data_values_per_vertex,
-							data_vertex_count);
+						typebitmask |= THREEJS_TYPE_VERTEX_TEX_COORD;
+						writeUVsBuffer(texture_coordinate0_buffer, texture_coordinate0_values_per_vertex,
+							texture_coordinate0_vertex_count);
 					}
 				}
-			}
-
-			/* export the normal buffer */
-			GLfloat *normal_buffer = NULL;
-			unsigned int normal_values_per_vertex, normal_vertex_count;
-			if (object->vertex_array->get_float_vertex_buffer(
-				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_NORMAL,
-				&normal_buffer, &normal_values_per_vertex, &normal_vertex_count)
-				&& (3 == normal_values_per_vertex) && (normal_vertex_count > 0))
-			{
 				if (time_step == 0)
 				{
-					typebitmask |= THREEJS_TYPE_VERTEX_NORMAL;
-					writeVertexBuffer("normals",
-						normal_buffer, normal_values_per_vertex,
-						normal_vertex_count);
+					writeIndexBuffer(object, typebitmask, position_vertex_count, 0);
 				}
-				if (number_of_time_steps > 1)
-				{
-					if (morphNormals)
-					{
-						morphNormalsExported = true;
-						writeMorphVertexBuffer("normals", &normalMorphString,
-							normal_buffer, normal_values_per_vertex,
-							normal_vertex_count, time_step);
-					}
-				}
-			}
-
-			/* export the texture coordinates buffer */
-			GLfloat *texture_coordinate0_buffer = NULL;
-			unsigned int texture_coordinate0_values_per_vertex,
-			texture_coordinate0_vertex_count;
-			if (object->vertex_array->get_float_vertex_buffer(
-				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_TEXTURE_COORDINATE_ZERO,
-				&texture_coordinate0_buffer, &texture_coordinate0_values_per_vertex,
-				&texture_coordinate0_vertex_count) && (texture_coordinate0_vertex_count > 0))
-			{
-				if (time_step == 0)
-				{
-					typebitmask |= THREEJS_TYPE_VERTEX_TEX_COORD;
-					writeUVsBuffer(texture_coordinate0_buffer, texture_coordinate0_values_per_vertex,
-						texture_coordinate0_vertex_count);
-				}
-			}
-			if (time_step == 0)
-			{
-				writeIndexBuffer(object, typebitmask, position_vertex_count, 0);
 			}
 		} break;
 		default:
@@ -1092,6 +1101,13 @@ void Threejs_export_glyph::exportGlyphsTransformation(struct GT_object *object, 
 		metadata["MorphColours"] = morphColoursExported;
 		metadata["MorphVertices"] = morphVerticesExported;
 	}
+	else
+	{
+		if (time_step == 0)
+		{
+			this->isEmpty = 1;
+		}
+	}
 }
 
 int Threejs_export_glyph::exportGraphicsObject(struct GT_object *object, int time_step)
@@ -1246,9 +1262,17 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 		{
 			if (time_step == 0)
 			{
-				writeVertexBuffer("vertices",
+				if (position_vertex_count > 0)
+				{
+					writeVertexBuffer("vertices",
 						position_vertex_buffer, position_values_per_vertex,
 						position_vertex_count);
+				}
+				else
+				{
+					this->isEmpty = 1;
+				}
+
 			}
 			if (number_of_time_steps > 1)
 			{
@@ -1262,77 +1286,79 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 			}
 		}
 
-		/* export the colour buffer */
-		if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
+		if (this->isEmpty == 0)
 		{
-			/* this case export the colour */
-			unsigned int colour_values_per_vertex, colour_vertex_count;
-			GLfloat *colour_buffer = (GLfloat *)NULL;
-			if (Graphics_object_create_colour_buffer_from_data(object,
-					&colour_buffer,
-					&colour_values_per_vertex, &colour_vertex_count)
-					&& (colour_vertex_count == position_vertex_count))
+			/* export the colour buffer */
+			if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
 			{
-				int *hex_colours = new int[colour_vertex_count];
-				GLfloat *colours = colour_buffer;
-				for (unsigned int i = 0; i < colour_vertex_count; i++)
+				/* this case export the colour */
+				unsigned int colour_values_per_vertex, colour_vertex_count;
+				GLfloat *colour_buffer = (GLfloat *)NULL;
+				if (Graphics_object_create_colour_buffer_from_data(object,
+						&colour_buffer,
+						&colour_values_per_vertex, &colour_vertex_count)
+						&& (colour_vertex_count == position_vertex_count))
 				{
-					hex_colours[i] = rgb_to_hex(colours[0], colours[1], colours[2]);
-					colours += colour_values_per_vertex;
-				}
-				if (time_step == 0)
-				{
-					typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
-					writeIntegerBuffer("colors",
-							hex_colours, 1, colour_vertex_count);
-				}
-				if (number_of_time_steps > 1)
-				{
-					if (morphColours)
+					int *hex_colours = new int[colour_vertex_count];
+					GLfloat *colours = colour_buffer;
+					for (unsigned int i = 0; i < colour_vertex_count; i++)
 					{
-						morphColoursExported = true;
-						writeMorphIntegerBuffer("colors", &colorsMorphString,
-								hex_colours, 1, colour_vertex_count, time_step);
+						hex_colours[i] = rgb_to_hex(colours[0], colours[1], colours[2]);
+						colours += colour_values_per_vertex;
 					}
-				}
-				delete[] hex_colours;
-				if (colour_buffer)
-				{
-					DEALLOCATE(colour_buffer);
-				}
-			}
-		}
-		else if ((mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_VERTEX_VALUE) ||
-			(mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE))
-		{
-			/* this case export the field data directly */
-			GLfloat *data_buffer = NULL;
-			unsigned int data_values_per_vertex, data_vertex_count;
-			if (object->vertex_array->get_float_vertex_buffer(
-					GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_DATA,
-					&data_buffer, &data_values_per_vertex, &data_vertex_count))
-			{
-				if (time_step == 0)
-				{
-					if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE)
-					{
-						typebitmask |= THREEJS_TYPE_FACE_COLOR;
-					}
-					else
+					if (time_step == 0)
 					{
 						typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
+						writeIntegerBuffer("colors",
+								hex_colours, 1, colour_vertex_count);
 					}
-					writeSpecialDataBuffer(object, data_buffer, data_values_per_vertex,
-							data_vertex_count);
+					if (number_of_time_steps > 1)
+					{
+						if (morphColours)
+						{
+							morphColoursExported = true;
+							writeMorphIntegerBuffer("colors", &colorsMorphString,
+									hex_colours, 1, colour_vertex_count, time_step);
+						}
+					}
+					delete[] hex_colours;
+					if (colour_buffer)
+					{
+						DEALLOCATE(colour_buffer);
+					}
 				}
 			}
-		}
+			else if ((mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_VERTEX_VALUE) ||
+				(mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE))
+			{
+				/* this case export the field data directly */
+				GLfloat *data_buffer = NULL;
+				unsigned int data_values_per_vertex, data_vertex_count;
+				if (object->vertex_array->get_float_vertex_buffer(
+						GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_DATA,
+						&data_buffer, &data_values_per_vertex, &data_vertex_count))
+				{
+					if (time_step == 0)
+					{
+						if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_PER_FACE_VALUE)
+						{
+							typebitmask |= THREEJS_TYPE_FACE_COLOR;
+						}
+						else
+						{
+							typebitmask |= THREEJS_TYPE_VERTEX_COLOR;
+						}
+						writeSpecialDataBuffer(object, data_buffer, data_values_per_vertex,
+								data_vertex_count);
+					}
+				}
+			}
 
-		if (time_step == 0)
-		{
-			writeIndexBuffer(object, typebitmask, position_vertex_count, 0);
+			if (time_step == 0)
+			{
+				writeIndexBuffer(object, typebitmask, position_vertex_count, 0);
+			}
 		}
-
 		object->buffer_binding = buffer_binding;
 		return 1;
 	}
@@ -1362,7 +1388,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 
 		/* cannot use the index as i will be using GL_LINE for rendering on threejs */
 		//FE_value *data_values = (0 != data_buffer) ? new FE_value[data_values_per_vertex] : 0;
-		int totalVertices =0;
+		int totalVertices = 0;
 
 		for (line_index = 0; line_index < line_count; line_index++)
 		{
@@ -1411,7 +1437,14 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		}
 		if (time_step == 0)
 		{
-			writeVertexBuffer("vertices", 	positions, position_values_per_vertex, totalVertices);
+			if (totalVertices > 0)
+			{
+				writeVertexBuffer("vertices", 	positions, position_values_per_vertex, totalVertices);
+			}
+			else
+			{
+				this->isEmpty = 1;
+			}
 		}
 		if (number_of_time_steps > 1)
 		{

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -718,7 +718,7 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 				this->isEmpty = true;
 			}
 
-			if (this->isEmpty == false)
+			if (!this->isEmpty)
 			{
 				/* export the colour buffer */
 				if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
@@ -1312,7 +1312,7 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 			this->isEmpty = true;
 		}
 
-		if (this->isEmpty == false)
+		if (!this->isEmpty)
 		{
 			/* export the colour buffer */
 			if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -675,7 +675,7 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 		{
 			/* export the vertices */
 			GLfloat *position_vertex_buffer = NULL;
-			unsigned int position_values_per_vertex, position_vertex_count;
+			unsigned int position_values_per_vertex = 0, position_vertex_count = 0;
 			if (object->vertex_array->get_float_vertex_buffer(
 				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_POSITION,
 				&position_vertex_buffer, &position_values_per_vertex,
@@ -683,14 +683,16 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 			{
 				if (time_step == 0)
 				{
-					if (position_vertex_count > 0) {
+					if (position_vertex_buffer && (position_values_per_vertex > 0) &&
+					(position_vertex_count > 0))
+					{
 						writeVertexBuffer("vertices",
 							position_vertex_buffer, position_values_per_vertex,
 							position_vertex_count);
 					}
 					else
 					{
-						this->isEmpty = 1;
+						this->isEmpty = true;
 					}
 				}
 				if (number_of_time_steps > 1)
@@ -704,8 +706,12 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 					}
 				}
 			}
+			else
+			{
+				this->isEmpty = true;
+			}
 
-			if (this->isEmpty == 0)
+			if (this->isEmpty == false)
 			{
 				/* export the colour buffer */
 				if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
@@ -823,10 +829,15 @@ int Threejs_export::exportGraphicsObject(struct GT_object *object, int time_step
 			}
 		} break;
 		default:
+			this->isEmpty = true;
 			break;
 		}
 		object->buffer_binding = buffer_binding;
 		return 1;
+	}
+	else
+	{
+		this->isEmpty = true;
 	}
 	return 0;
 }
@@ -1105,7 +1116,7 @@ void Threejs_export_glyph::exportGlyphsTransformation(struct GT_object *object, 
 	{
 		if (time_step == 0)
 		{
-			this->isEmpty = 1;
+			this->isEmpty = true;
 		}
 	}
 }
@@ -1144,6 +1155,10 @@ int Threejs_export_glyph::exportGraphicsObject(struct GT_object *object, int tim
 		}
 		object->buffer_binding = buffer_binding;
 		return 1;
+	}
+	else
+	{
+		this->isEmpty = true;
 	}
 	return 0;
 }
@@ -1270,7 +1285,7 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 				}
 				else
 				{
-					this->isEmpty = 1;
+					this->isEmpty = true;
 				}
 
 			}
@@ -1285,8 +1300,12 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 				}
 			}
 		}
+		else
+		{
+			this->isEmpty = true;
+		}
 
-		if (this->isEmpty == 0)
+		if (this->isEmpty == false)
 		{
 			/* export the colour buffer */
 			if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
@@ -1361,6 +1380,10 @@ int Threejs_export_point::exportGraphicsObject(struct GT_object *object, int tim
 		}
 		object->buffer_binding = buffer_binding;
 		return 1;
+	}
+	else
+	{
+		this->isEmpty = true;
 	}
 	return 0;
 }
@@ -1443,7 +1466,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 			}
 			else
 			{
-				this->isEmpty = 1;
+				this->isEmpty = true;
 			}
 		}
 		if (number_of_time_steps > 1)
@@ -1462,6 +1485,10 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		object->buffer_binding = buffer_binding;
 		DEALLOCATE(positions);
 		return 1;
+	}
+	else
+	{
+		this->isEmpty = true;
 	}
 
 	return 0;

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -81,11 +81,18 @@ int Threejs_export::beginExport()
 
 int Threejs_export::endExport()
 {
-	outputString += verticesMorphString;
-	outputString += colorsMorphString;
-	outputString += normalMorphString;
-	outputString += facesString;
-	outputString += "}\n";
+	if (this->isValid())
+	{
+		outputString += verticesMorphString;
+		outputString += colorsMorphString;
+		outputString += normalMorphString;
+		outputString += facesString;
+		outputString += "}\n";
+	}
+	else
+	{
+		outputString.clear();
+	}
 	return 1;
 }
 

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -24,10 +24,19 @@ class Threejs_export
 {
 protected:
 
+	char *filename;
+	cmzn_streaminformation_scene_io_data_type mode;
 	bool morphVerticesExported, morphColoursExported, morphNormalsExported;
 	int morphVertices, morphColours, morphNormals;
 	int number_of_time_steps;
 	char *groupName, *regionPath;
+	double textureSizes[3];
+	std::string verticesMorphString;
+	std::string colorsMorphString;
+	std::string normalMorphString;
+	std::string facesString;
+	std::string outputString;
+	int isEmpty;
 
 	void writeVertexBuffer(const char *output_variable_name,
 		GLfloat *vertex_buffer, unsigned int values_per_vertex,
@@ -56,16 +65,6 @@ protected:
 	/* texture coordinates export*/
 	void writeUVsBuffer(GLfloat *texture_buffer, unsigned int values_per_vertex,
 		unsigned int vertex_count);
-
-protected:
-	char *filename;
-	cmzn_streaminformation_scene_io_data_type mode;
-	std::string facesString;
-	std::string verticesMorphString;
-	std::string normalMorphString;
-	std::string colorsMorphString;
-	std::string outputString;
-	double textureSizes[3];
 
 public:
 
@@ -104,6 +103,7 @@ public:
 		normalMorphString.clear();
 		facesString.clear();
 		outputString.clear();
+		isEmpty = 0;
 	}
 
 	virtual ~Threejs_export();
@@ -115,6 +115,11 @@ public:
 	int beginExport();
 
 	int endExport();
+
+	int isValid() const
+	{
+		return (isEmpty == 0);
+	}
 
 	const char *getGroupName() const
 	{

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -36,7 +36,7 @@ protected:
 	std::string normalMorphString;
 	std::string facesString;
 	std::string outputString;
-	int isEmpty;
+	bool isEmpty;
 
 	void writeVertexBuffer(const char *output_variable_name,
 		GLfloat *vertex_buffer, unsigned int values_per_vertex,
@@ -103,7 +103,7 @@ public:
 		normalMorphString.clear();
 		facesString.clear();
 		outputString.clear();
-		isEmpty = 0;
+		isEmpty = false;
 	}
 
 	virtual ~Threejs_export();
@@ -116,9 +116,9 @@ public:
 
 	int endExport();
 
-	int isValid() const
+	bool isValid() const
 	{
-		return (isEmpty == 0);
+		return (isEmpty == false);
 	}
 
 	const char *getGroupName() const

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -118,7 +118,7 @@ public:
 
 	bool isValid() const
 	{
-		return (isEmpty == false);
+		return !isEmpty;
 	}
 
 	const char *getGroupName() const

--- a/src/stream/scene_stream.cpp
+++ b/src/stream/scene_stream.cpp
@@ -107,23 +107,34 @@ int cmzn_scene_write(cmzn_scene_id scene,
 				{
 					if (file_resource)
 					{
-						char *file_name = file_resource->getFileName();
-						if (file_name)
+						if (output_string[i].empty() == false)
 						{
-							FILE *export_file = fopen(file_name,"w");
-							fprintf(export_file, "%s", output_string[i].c_str());
-							fclose(export_file);
-							DEALLOCATE(file_name);
-							i++;
+							char *file_name = file_resource->getFileName();
+							if (file_name)
+							{	
+								FILE *export_file = fopen(file_name,"w");
+								fprintf(export_file, "%s", output_string[i].c_str());
+								fclose(export_file);
+								DEALLOCATE(file_name);
+							}
 						}
 						cmzn_streamresource_file_destroy(&file_resource);
+						i++;
 					}
 					else if (NULL != (memory_resource = cmzn_streamresource_cast_memory(stream)))
 					{
-						char *buffer_out = duplicate_string(output_string[i].c_str());
-						unsigned int buffer_size = static_cast<unsigned int>(strlen(buffer_out));
-						memory_resource->setBuffer(buffer_out, buffer_size);
-						cmzn_streamresource_memory_destroy(&memory_resource);
+						if (output_string[i].empty() == false)
+						{
+							char *buffer_out = duplicate_string(output_string[i].c_str());
+							unsigned int buffer_size = static_cast<unsigned int>(strlen(buffer_out));
+							memory_resource->setBuffer(buffer_out, buffer_size);
+							cmzn_streamresource_memory_destroy(&memory_resource);
+						}
+						else
+						{
+							memory_resource->setBuffer(nullptr, 0);
+							cmzn_streamresource_memory_destroy(&memory_resource);
+						}
 						i++;
 					}
 					else

--- a/src/stream/scene_stream.cpp
+++ b/src/stream/scene_stream.cpp
@@ -107,7 +107,7 @@ int cmzn_scene_write(cmzn_scene_id scene,
 				{
 					if (file_resource)
 					{
-						if (output_string[i].empty() == false)
+						if (!output_string[i].empty())
 						{
 							char *file_name = file_resource->getFileName();
 							if (file_name)
@@ -123,7 +123,7 @@ int cmzn_scene_write(cmzn_scene_id scene,
 					}
 					else if (NULL != (memory_resource = cmzn_streamresource_cast_memory(stream)))
 					{
-						if (output_string[i].empty() == false)
+						if (!output_string[i].empty())
 						{
 							char *buffer_out = duplicate_string(output_string[i].c_str());
 							unsigned int buffer_size = static_cast<unsigned int>(strlen(buffer_out));

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -866,6 +866,38 @@ TEST(cmzn_scene, threejs_export_empty_surface_cpp)
 
 	EXPECT_EQ(CMZN_OK, result = surfaces.setCoordinateField(coordinateField));
 
+	//Export from root region scene
+	StreaminformationScene si = zinc.scene.createStreaminformationScene();
+	EXPECT_TRUE(si.isValid());
+
+	EXPECT_EQ(CMZN_OK, result = si.setIOFormat(si.IO_FORMAT_THREEJS));
+
+	//one empty and one metadata- 2 in total
+	EXPECT_EQ(2, result = si.getNumberOfResourcesRequired());
+
+	EXPECT_EQ(0, result = si.getNumberOfTimeSteps());
+
+	StreamresourceMemory memeory_sr = si.createStreamresourceMemory();
+	EXPECT_EQ(CMZN_OK, result = zinc.scene.write(si));
+
+	StreamresourceMemory memeory_sr2 = si.createStreamresourceMemory();
+	EXPECT_EQ(CMZN_OK, result = zinc.scene.write(si));
+
+	const char *memory_buffer;
+	unsigned int size = 0;
+
+	result = memeory_sr.getBuffer((const void**)&memory_buffer, &size);
+	EXPECT_EQ(CMZN_OK, result);
+
+	const char *temp_char = strstr ( memory_buffer, "Surfaces");
+	EXPECT_EQ(static_cast<char *>(0), temp_char);
+
+	result = memeory_sr2.getBuffer((const void**)&memory_buffer, &size);
+	EXPECT_EQ(CMZN_OK, result);
+
+	temp_char = strstr ( memory_buffer, "materials");
+	EXPECT_EQ(static_cast<char *>(0), temp_char);
+
 	GraphicsPoints nodes = s1.createGraphicsPoints();
 	EXPECT_TRUE(nodes.isValid());
 	EXPECT_EQ(CMZN_OK, result = nodes.setCoordinateField(coordinateField));
@@ -879,29 +911,21 @@ TEST(cmzn_scene, threejs_export_empty_surface_cpp)
 	EXPECT_EQ(CMZN_OK, result = pointAttr.setGlyph(pointGlyph));
 
 	//Export from root region scene
-	StreaminformationScene si = zinc.scene.createStreaminformationScene();
+	si = zinc.scene.createStreaminformationScene();
 	EXPECT_TRUE(si.isValid());
 
 	EXPECT_EQ(CMZN_OK, result = si.setIOFormat(si.IO_FORMAT_THREEJS));
 
-	//one empty and two valid - 3 in total
+	//one empty, one point graphics and one metadata- 3 in total
 	EXPECT_EQ(3, result = si.getNumberOfResourcesRequired());
 
-	EXPECT_EQ(0, result = si.getNumberOfTimeSteps());
-
-	StreamresourceMemory memeory_sr = si.createStreamresourceMemory();
-
+	memeory_sr = si.createStreamresourceMemory();
 	EXPECT_EQ(CMZN_OK, result = zinc.scene.write(si));
-
-	const char *memory_buffer;
-	unsigned int size = 0;
 
 	result = memeory_sr.getBuffer((const void**)&memory_buffer, &size);
 	EXPECT_EQ(CMZN_OK, result);
 
-	printf(memory_buffer);
-
-	const char *temp_char = strstr ( memory_buffer, "Surfaces");
+	temp_char = strstr ( memory_buffer, "Surfaces");
 	EXPECT_EQ(static_cast<char *>(0), temp_char);
 
 	temp_char = strstr ( memory_buffer, "Points");

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -948,30 +948,17 @@ TEST(cmzn_scene, threejs_export_empty_vertices_cpp)
 	Fieldmodule fm = r1.getFieldmodule();
 	EXPECT_TRUE(fm.isValid());
 
-	EXPECT_EQ(CMZN_OK, result = r1.readFile(TestResources::getLocation(TestResources::FIELDMODULE_CUBE_RESOURCE)));
-
 	GraphicsSurfaces surfaces = s1.createGraphicsSurfaces();
 	EXPECT_TRUE(surfaces.isValid());
-
-	Field coordinateField = fm.findFieldByName("coordinates");
-	EXPECT_TRUE(coordinateField.isValid());
-
-	EXPECT_EQ(CMZN_OK, result = surfaces.setCoordinateField(coordinateField));
 
 	//Export from root region scene
 	StreaminformationScene si = zinc.scene.createStreaminformationScene();
 	EXPECT_TRUE(si.isValid());
 
-	Scene s2 = zinc.root_region.getScene();
-	EXPECT_TRUE(s2.isValid());
-
-	GraphicsSurfaces surfaces2 = s2.createGraphicsSurfaces();
-	EXPECT_TRUE(surfaces2.isValid());
-
 	EXPECT_EQ(CMZN_OK, result = si.setIOFormat(si.IO_FORMAT_THREEJS));
 
-	//one empty and two valid - 3 in total
-	EXPECT_EQ(3, result = si.getNumberOfResourcesRequired());
+	//one empty and one metadata - 2 in total
+	EXPECT_EQ(2, result = si.getNumberOfResourcesRequired());
 
 	EXPECT_EQ(0, result = si.getNumberOfTimeSteps());
 
@@ -993,26 +980,12 @@ TEST(cmzn_scene, threejs_export_empty_vertices_cpp)
 	EXPECT_EQ(CMZN_OK, result);
 
 	const char *temp_char = strstr ( memory_buffer, "Surfaces");
-	EXPECT_NE(static_cast<char *>(0), temp_char);
-
-	temp_char = strstr ( memory_buffer, "MorphVertices");
-	EXPECT_NE(static_cast<char *>(0), temp_char);
-
-	temp_char = strstr ( memory_buffer, "\"RegionPath\" : \"bob\"");
-	EXPECT_NE(static_cast<char *>(0), temp_char);
-
-	//Check for the absence of empty graphics
-	temp_char = strstr ( memory_buffer, "\"RegionPath\" : \"\"");
 	EXPECT_EQ(static_cast<char *>(0), temp_char);
 
 	result = memeory_sr2.getBuffer((const void**)&memory_buffer, &size);
 	EXPECT_EQ(CMZN_OK, result);
+	EXPECT_EQ(nullptr, memory_buffer);
 
-	temp_char = strstr ( memory_buffer, "vertices");
-	EXPECT_NE(static_cast<char *>(0), temp_char);
-
-	temp_char = strstr ( memory_buffer, "faces");
-	EXPECT_NE(static_cast<char *>(0), temp_char);
 }
 
 TEST(cmzn_scene, threejs_export_cpp)

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -766,7 +766,6 @@ TEST(cmzn_scene, threejs_export_texture_cpp)
 	EXPECT_NE(static_cast<char *>(0), temp_char);
 }
 
-
 TEST(cmzn_scene, threejs_export_region_cpp)
 {
 	ZincTestSetupCpp zinc;
@@ -829,6 +828,90 @@ TEST(cmzn_scene, threejs_export_region_cpp)
 
 	temp_char = strstr ( memory_buffer, "\"RegionPath\" : \"bob\"");
 	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	result = memeory_sr2.getBuffer((const void**)&memory_buffer, &size);
+	EXPECT_EQ(CMZN_OK, result);
+
+	temp_char = strstr ( memory_buffer, "vertices");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	temp_char = strstr ( memory_buffer, "faces");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+}
+
+TEST(cmzn_scene, threejs_export_empty_vertices_cpp)
+{
+	ZincTestSetupCpp zinc;
+
+	int result;
+
+	//Create a new child region, read in the file the run the
+	//export from root region scene
+	Region r1 = zinc.root_region.createChild("bob");
+	EXPECT_TRUE(r1.isValid());
+
+	Scene s1 = r1.getScene();
+	EXPECT_TRUE(s1.isValid());
+
+	Fieldmodule fm = r1.getFieldmodule();
+	EXPECT_TRUE(fm.isValid());
+
+	EXPECT_EQ(CMZN_OK, result = r1.readFile(TestResources::getLocation(TestResources::FIELDMODULE_CUBE_RESOURCE)));
+
+	GraphicsSurfaces surfaces = s1.createGraphicsSurfaces();
+	EXPECT_TRUE(surfaces.isValid());
+
+	Field coordinateField = fm.findFieldByName("coordinates");
+	EXPECT_TRUE(coordinateField.isValid());
+
+	EXPECT_EQ(CMZN_OK, result = surfaces.setCoordinateField(coordinateField));
+
+	//Export from root region scene
+	StreaminformationScene si = zinc.scene.createStreaminformationScene();
+	EXPECT_TRUE(si.isValid());
+
+	Scene s2 = zinc.root_region.getScene();
+	EXPECT_TRUE(s2.isValid());
+
+	GraphicsSurfaces surfaces2 = s2.createGraphicsSurfaces();
+	EXPECT_TRUE(surfaces2.isValid());
+
+	EXPECT_EQ(CMZN_OK, result = si.setIOFormat(si.IO_FORMAT_THREEJS));
+
+	//one empty and two valid - 3 in total
+	EXPECT_EQ(3, result = si.getNumberOfResourcesRequired());
+
+	EXPECT_EQ(0, result = si.getNumberOfTimeSteps());
+
+	double double_result = 0.0;
+	EXPECT_EQ(0.0, double_result = si.getInitialTime());
+	EXPECT_EQ(0.0, double_result = si.getFinishTime());
+
+	EXPECT_EQ(CMZN_OK, result = si.setIODataType(si.IO_DATA_TYPE_COLOUR));
+
+	StreamresourceMemory memeory_sr = si.createStreamresourceMemory();
+	StreamresourceMemory memeory_sr2 = si.createStreamresourceMemory();
+
+	EXPECT_EQ(CMZN_OK, result = zinc.scene.write(si));
+
+	const char *memory_buffer;
+	unsigned int size = 0;
+
+	result = memeory_sr.getBuffer((const void**)&memory_buffer, &size);
+	EXPECT_EQ(CMZN_OK, result);
+
+	const char *temp_char = strstr ( memory_buffer, "Surfaces");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	temp_char = strstr ( memory_buffer, "MorphVertices");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	temp_char = strstr ( memory_buffer, "\"RegionPath\" : \"bob\"");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	//Check for the absence of empty graphics
+	temp_char = strstr ( memory_buffer, "\"RegionPath\" : \"\"");
+	EXPECT_EQ(static_cast<char *>(0), temp_char);
 
 	result = memeory_sr2.getBuffer((const void**)&memory_buffer, &size);
 	EXPECT_EQ(CMZN_OK, result);

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -895,8 +895,7 @@ TEST(cmzn_scene, threejs_export_empty_surface_cpp)
 	result = memeory_sr2.getBuffer((const void**)&memory_buffer, &size);
 	EXPECT_EQ(CMZN_OK, result);
 
-	temp_char = strstr ( memory_buffer, "materials");
-	EXPECT_EQ(static_cast<char *>(0), temp_char);
+	EXPECT_EQ(nullptr, memory_buffer);
 
 	GraphicsPoints nodes = s1.createGraphicsPoints();
 	EXPECT_TRUE(nodes.isValid());


### PR DESCRIPTION
Mark an ZincJS export as empty and omit it from the metadata file. Update documentation for the relevant APIs. A test has also been added.

fix #200 