### PR TITLE
Maintain graphics order on ZincJS exports

### DIFF
--- a/src/graphics/render_gl.cpp
+++ b/src/graphics/render_gl.cpp
@@ -11,7 +11,7 @@ GL rendering calls - API specific.
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include <stdio.h>
 #include <math.h>
-#include <map>
+#include <list>
 #include "opencmiss/zinc/zincconfigure.h"
 
 #include "general/mystring.h"
@@ -573,7 +573,7 @@ class Render_graphics_opengl_threejs : public Render_graphics_opengl_vertex_buff
 {
 public:
 
-	std::map<cmzn_graphics *, Threejs_export *> exports_map;
+	std::list<Threejs_export *> exports_list;
 	char *file_prefix;
 	double begin_time, end_time;
 	int number_of_time_steps, current_time_frame;
@@ -596,7 +596,7 @@ public:
 		filenames(filenamesIn),
 		isInline(isInlineIn)
 	{
-		exports_map.clear();
+		exports_list.clear();
 		current_time_frame = 0;
 		output_string = output_string_in;
 		morphVertices = morphVerticesIn;
@@ -613,7 +613,6 @@ public:
 	int get_number_of_entries()
 	{
 		int size = 0;
-		Threejs_export *threejs_export = 0;
 
 		if (isInline)
 		{
@@ -622,12 +621,11 @@ public:
 		}
 		else
 		{
-			for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
-				export_iter != exports_map.end(); export_iter++)
+			for (std::list<Threejs_export *>::iterator item = exports_list.begin();
+				item != exports_list.end(); item++)
 			{
 				size++;
-				threejs_export =  export_iter->second;
-				if (dynamic_cast<Threejs_export_glyph*>(threejs_export))
+				if (dynamic_cast<Threejs_export_glyph*>(*item))
 					size++;
 			}
 		}
@@ -641,18 +639,18 @@ public:
 	{
 		Json::Value root = Json::arrayValue;
 		int i = 1;
-		for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
-			export_iter != exports_map.end(); export_iter++)
+		for (std::list<Threejs_export *>::iterator item = exports_list.begin();
+			item != exports_list.end(); item++)
 		{
-			if (export_iter->second->isValid())
+			if ((*item)->isValid())
 			{
 				Json::Value graphics_json;
-				graphics_json["MorphVertices"] = export_iter->second->getMorphVerticesExported();
-				graphics_json["MorphColours"] = export_iter->second->getMorphColoursExported();
-				graphics_json["MorphNormals"] = export_iter->second->getMorphNormalsExported();
+				graphics_json["MorphVertices"] = (*item)->getMorphVerticesExported();
+				graphics_json["MorphColours"] = (*item)->getMorphColoursExported();
+				graphics_json["MorphNormals"] = (*item)->getMorphNormalsExported();
 				if (isInline)
 				{
-					graphics_json["Inline"]["URL"]= export_iter->second->getExportJson();
+					graphics_json["Inline"]["URL"]= (*item)->getExportJson();
 				}
 				else
 				{
@@ -667,16 +665,16 @@ public:
 						graphics_json["URL"] = temp;
 					}
 				}
-				const char *group_name = export_iter->second->getGroupName();
+				const char *group_name = (*item)->getGroupName();
 				if (group_name)
 					graphics_json["GroupName"] = group_name;
-				const char *region_path = export_iter->second->getRegionPath();
+				const char *region_path = (*item)->getRegionPath();
 				if (region_path)
 					graphics_json["RegionPath"] = region_path;
 
-				Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(export_iter->second);
-				Threejs_export_line *line_export = dynamic_cast<Threejs_export_line*>(export_iter->second);
-				Threejs_export_point *point_export = dynamic_cast<Threejs_export_point*>(export_iter->second);
+				Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(*item);
+				Threejs_export_line *line_export = dynamic_cast<Threejs_export_line*>(*item);
+				Threejs_export_point *point_export = dynamic_cast<Threejs_export_point*>(*item);
 				if (glyph_export)
 				{
 					graphics_json["Type"]="Glyph";
@@ -731,16 +729,16 @@ public:
 			if (isInline == 0)
 			{
 				int i = 1;
-				for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
-					export_iter != exports_map.end(); export_iter++)
+				for (std::list<Threejs_export *>::iterator item = exports_list.begin();
+					item != exports_list.end(); item++)
 				{
-					Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(export_iter->second);
+					Threejs_export_glyph *glyph_export = dynamic_cast<Threejs_export_glyph*>(*item);
 					if (glyph_export)
 					{
 						(*output_string)[i] = std::string(*glyph_export->getGlyphTransformationExportString());
 						i++;
 					}
-					(*output_string)[i] = std::string(*(export_iter->second->getExportString()));
+					(*output_string)[i] = std::string(*((*item)->getExportString()));
 					i++;
 				}
 			}
@@ -748,14 +746,13 @@ public:
 		return 1;
 	}
 
-	void clear_exports_map()
+	void clear_exports_list()
 	{
-		for (std::map<cmzn_graphics *, Threejs_export *>::iterator export_iter = exports_map.begin();
-			export_iter != exports_map.end(); export_iter++)
+		while (exports_list.size() > 0)
 		{
-			delete export_iter->second;
+			delete exports_list.back();
+			exports_list.pop_back();
 		}
-		exports_map.clear();
 	}
 
 	virtual int cmzn_scene_compile_members(cmzn_scene *scene)
@@ -818,7 +815,7 @@ public:
 	template <class Threejs_export_class>
 	int Graphics_export(cmzn_graphics *graphics)
 	{
-		int return_code = 1;
+		int return_code = 0;
 		GT_object *graphics_object = cmzn_graphics_get_graphics_object(
 			graphics);
 		Threejs_export_class *threejs_export = 0;
@@ -859,7 +856,7 @@ public:
 			const bool morphNormalsAllowed = graphicsIsTimeDependent && morphNormals;
 			threejs_export = new Threejs_export_class(new_file_prefix, number_of_time_steps, mode,
 				morphsVerticesAllowed, morphsColoursAllowed, morphNormalsAllowed, &textureSizes[0], group_name,
-				this->region_path);
+				this->region_path, graphics);
 			threejs_export->beginExport();
 			threejs_export->exportMaterial(material);
 			cmzn_material_destroy(&material);
@@ -868,21 +865,28 @@ public:
 			cmzn_field_destroy(&groupField);
 			if (group_name)
 				DEALLOCATE(group_name);
-			exports_map.insert(std::make_pair(graphics, threejs_export));
+			exports_list.push_back(threejs_export);
 		}
 		else
 		{
-			std::map<cmzn_graphics *, Threejs_export *>::iterator iter = exports_map.find(graphics);
-			if (iter != exports_map.end())
+			std::list<Threejs_export *>::iterator item = exports_list.begin();
+			while ((threejs_export == 0) && (item != exports_list.end()))
 			{
-				threejs_export = dynamic_cast<Threejs_export_class*>(iter->second);
+				if ((*item)->isExportForGraphics(graphics))
+				{
+					threejs_export = dynamic_cast<Threejs_export_class *>(*item);
+				}
+				item++;
 			}
 		}
-		return_code = threejs_export->exportGraphicsObject(graphics_object, current_time_frame);
-		if ((number_of_time_steps == 0) || (number_of_time_steps == 1) ||
-			(number_of_time_steps - 1 == current_time_frame))
+		if (threejs_export)
 		{
-			threejs_export->endExport();
+			return_code = threejs_export->exportGraphicsObject(graphics_object, current_time_frame);
+			if ((number_of_time_steps == 0) || (number_of_time_steps == 1) ||
+				(number_of_time_steps - 1 == current_time_frame))
+			{
+				threejs_export->endExport();
+			}
 		}
 		return return_code;
 
@@ -935,7 +939,7 @@ public:
 	int Scene_tree_execute(cmzn_scene *scene)
 	{
 		write_output_string();
-		clear_exports_map();
+		clear_exports_list();
 		return 1;
 	}
 

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -32,8 +32,7 @@ protected:
 	int morphVertices, morphColours, morphNormals;
 	int number_of_time_steps;
 	char *groupName, *regionPath;
-	//This is a weak pointer
-	cmzn_graphics_id graphics;
+	cmzn_graphics *graphics; // not accessed
 	double textureSizes[3];
 	std::string verticesMorphString;
 	std::string colorsMorphString;
@@ -76,7 +75,7 @@ public:
 			cmzn_streaminformation_scene_io_data_type mode_in,
 			int morphVerticesIn, int morphColoursIn, int morphNormalsIn, 
 			double *textureSizesIn, const char *groupNameIn,
-			const char *regionPathIn, cmzn_graphics_id graphicsIn) :
+			const char *regionPathIn, cmzn_graphics *graphicsIn) :
 		filename(duplicate_string(filename_in)),
 		mode(mode_in),
 		morphVerticesExported(false),
@@ -142,7 +141,7 @@ public:
 
 	std::string *getExportString();
 
-	bool isExportForGraphics(cmzn_graphics_id graphicsIn)
+	bool isExportForGraphics(cmzn_graphics *graphicsIn)
 	{
 		return (this->graphics == graphicsIn);
 	}
@@ -192,7 +191,7 @@ public:
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
 		double *textureSizesIn, const char *groupNameIn,
-		const char* regionPathIn, cmzn_graphics_id graphicsIn) :
+		const char* regionPathIn, cmzn_graphics *graphicsIn) :
 		Threejs_export(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
 		groupNameIn, regionPathIn, graphicsIn)
@@ -229,7 +228,7 @@ public:
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
 		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn,
-		cmzn_graphics_id graphicsIn) :
+		cmzn_graphics *graphicsIn) :
 		Threejs_export(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
 		groupNameIn, regionPathIn, graphicsIn)
@@ -253,7 +252,7 @@ public:
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
 		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn,
-		cmzn_graphics_id graphicsIn) :
+		cmzn_graphics *graphicsIn) :
 			Threejs_export_point(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
 		groupNameIn,  regionPathIn, graphicsIn)

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -141,22 +141,22 @@ public:
 
 	std::string *getExportString();
 
-	bool isExportForGraphics(cmzn_graphics *graphicsIn)
+	bool isExportForGraphics(cmzn_graphics *graphicsIn) const
 	{
 		return (this->graphics == graphicsIn);
 	}
 
-	bool getMorphVerticesExported()
+	bool getMorphVerticesExported() const
 	{
 		return morphVerticesExported;
 	}
 
-	bool getMorphColoursExported()
+	bool getMorphColoursExported() const
 	{
 		return morphColoursExported;
 	}
 
-	bool getMorphNormalsExported()
+	bool getMorphNormalsExported() const
 	{
 		return morphNormalsExported;
 	}

--- a/src/graphics/threejs_export.hpp
+++ b/src/graphics/threejs_export.hpp
@@ -14,6 +14,8 @@
 #include "graphics/render_gl.h"
 #include <string>
 #include "jsoncpp/json.h"
+#include "opencmiss/zinc/types/graphicsid.h"
+
 
 struct GT_object;
 
@@ -30,6 +32,8 @@ protected:
 	int morphVertices, morphColours, morphNormals;
 	int number_of_time_steps;
 	char *groupName, *regionPath;
+	//This is a weak pointer
+	cmzn_graphics_id graphics;
 	double textureSizes[3];
 	std::string verticesMorphString;
 	std::string colorsMorphString;
@@ -72,7 +76,7 @@ public:
 			cmzn_streaminformation_scene_io_data_type mode_in,
 			int morphVerticesIn, int morphColoursIn, int morphNormalsIn, 
 			double *textureSizesIn, const char *groupNameIn,
-			const char *regionPathIn) :
+			const char *regionPathIn, cmzn_graphics_id graphicsIn) :
 		filename(duplicate_string(filename_in)),
 		mode(mode_in),
 		morphVerticesExported(false),
@@ -83,7 +87,8 @@ public:
 		morphNormals(morphNormalsIn),
 		number_of_time_steps(number_of_time_steps_in),
 		groupName(groupNameIn ? duplicate_string(groupNameIn) : nullptr),
-		regionPath(regionPathIn ? duplicate_string(regionPathIn) : nullptr)
+		regionPath(regionPathIn ? duplicate_string(regionPathIn) : nullptr),
+		graphics(graphicsIn)
 	{
 		if (textureSizesIn)
 		{
@@ -130,11 +135,17 @@ public:
 	{
 		return regionPath;
 	}
+	
 
 	/* this return json format describing colours and transformation of the glyph */
 	Json::Value getExportJson();
 
 	std::string *getExportString();
+
+	bool isExportForGraphics(cmzn_graphics_id graphicsIn)
+	{
+		return (this->graphics == graphicsIn);
+	}
 
 	bool getMorphVerticesExported()
 	{
@@ -181,10 +192,10 @@ public:
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
 		double *textureSizesIn, const char *groupNameIn,
-		const char* regionPathIn) :
+		const char* regionPathIn, cmzn_graphics_id graphicsIn) :
 		Threejs_export(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
-		groupNameIn, regionPathIn)
+		groupNameIn, regionPathIn, graphicsIn)
 	{
 		glyphTransformationString.clear();
 		glyphGeometriesURLName = 0;
@@ -217,10 +228,11 @@ public:
 	Threejs_export_point(const char *filename_in, int number_of_time_steps_in,
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
-		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn) :
+		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn,
+		cmzn_graphics_id graphicsIn) :
 		Threejs_export(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
-		groupNameIn, regionPathIn)
+		groupNameIn, regionPathIn, graphicsIn)
 	{
 	}
 
@@ -240,10 +252,11 @@ public:
 	Threejs_export_line(const char *filename_in, int number_of_time_steps_in,
 		cmzn_streaminformation_scene_io_data_type mode_in,
 		int morphVerticesIn, int morphColoursIn, int morphNormalsIn,
-		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn) :
+		double *textureSizesIn, const char *groupNameIn, const char* regionPathIn,
+		cmzn_graphics_id graphicsIn) :
 			Threejs_export_point(filename_in, number_of_time_steps_in,
 		mode_in, morphVerticesIn, morphColoursIn, morphNormalsIn, textureSizesIn,
-		groupNameIn,  regionPathIn)
+		groupNameIn,  regionPathIn, graphicsIn)
 	{
 	}
 


### PR DESCRIPTION
Maintain graphics order on ZincJS exports by replacing exports container from map to list. Exports are pushed to the back of the list in the same order as the rendering thus maintaining the order of graphics exports.