### PR TITLE
Add support to spectrum colour exports with lines

### DIFF
--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1471,7 +1471,6 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_ELEMENT_INDEX_COUNT,
 				line_index, 1, &index_count);
 			position_vertex = position_buffer + position_values_per_vertex * index_start;
-			// the following fills out the unused vertices on the exports
 			for (i = 0; i < index_count; ++i)
 			{
 				if (hex_colours && output_hex_colours)
@@ -1484,6 +1483,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 					positions[currentIndex+j] = position_vertex[j];
 				}
 				currentIndex += position_values_per_vertex;
+				// the following fills out the unused vertices on the exports
 				if ((i != 0) && (i != index_count - 1))
 				{
 					for (unsigned int j = 0; j < position_values_per_vertex; ++j)

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1471,7 +1471,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_ELEMENT_INDEX_COUNT,
 				line_index, 1, &index_count);
 			position_vertex = position_buffer + position_values_per_vertex * index_start;
-
+			// the following fills out the unused vertices on the exports
 			for (i = 0; i < index_count; ++i)
 			{
 				if (hex_colours && output_hex_colours)
@@ -1491,6 +1491,11 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 						positions[currentIndex+j] = position_vertex[j];
 					}
 					currentIndex += position_values_per_vertex;
+					if (hex_colours && output_hex_colours)
+					{
+						output_hex_colours[hex_count] = hex_colours[index_start + i + 1];
+						hex_count++;
+					}
 				}
 				position_vertex += position_values_per_vertex;
 			}

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1410,13 +1410,13 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		object->vertex_array->get_float_vertex_buffer(
 			GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_POSITION,
 			&position_buffer, &position_values_per_vertex, &position_vertex_count);
-		/* this case export the colour */
-		unsigned int colour_values_per_vertex, colour_vertex_count;
-			GLfloat *colour_buffer = (GLfloat *)NULL;
 		int *hex_colours = nullptr, *output_hex_colours = nullptr;
 		/* Create the hex arrays for exporting */
 		if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
 		{
+			/* this case export the colour */
+			unsigned int colour_values_per_vertex, colour_vertex_count;
+			GLfloat *colour_buffer = (GLfloat *)NULL;
 			if (Graphics_object_create_colour_buffer_from_data(object,
 				&colour_buffer,
 				&colour_values_per_vertex, &colour_vertex_count)

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1414,7 +1414,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		unsigned int colour_values_per_vertex, colour_vertex_count;
 			GLfloat *colour_buffer = (GLfloat *)NULL;
 		int *hex_colours = nullptr, *output_hex_colours = nullptr;
-		/* export the colour buffer */
+		/* Create the hex arrays for exporting */
 		if (mode == CMZN_STREAMINFORMATION_SCENE_IO_DATA_TYPE_COLOUR)
 		{
 			if (Graphics_object_create_colour_buffer_from_data(object,
@@ -1451,6 +1451,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 
 		GLfloat *positions = 0;
 		ALLOCATE(positions, GLfloat, position_values_per_vertex * totalVertices);
+		//Create an expanded array to hold all hex colours
 		if (hex_colours)
 		{
 			output_hex_colours = new int[totalVertices];

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1416,7 +1416,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		{
 			/* this case export the colour */
 			unsigned int colour_values_per_vertex, colour_vertex_count;
-			GLfloat *colour_buffer = (GLfloat *)NULL;
+			GLfloat *colour_buffer = nullptr;
 			if (Graphics_object_create_colour_buffer_from_data(object,
 				&colour_buffer,
 				&colour_values_per_vertex, &colour_vertex_count)
@@ -1462,7 +1462,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 		for (line_index = 0; line_index < line_count; line_index++)
 		{
 			unsigned int i, index_start, index_count;
-			GLfloat *position_vertex = 0;
+			GLfloat *position_vertex = nullptr;
 
 			object->vertex_array->get_unsigned_integer_attribute(
 				GRAPHICS_VERTEX_ARRAY_ATTRIBUTE_TYPE_ELEMENT_INDEX_START,

--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1493,7 +1493,7 @@ int Threejs_export_line::exportGraphicsObject(struct GT_object *object, int time
 					currentIndex += position_values_per_vertex;
 					if (hex_colours && output_hex_colours)
 					{
-						output_hex_colours[hex_count] = hex_colours[index_start + i + 1];
+						output_hex_colours[hex_count] = hex_colours[index_start + i];
 						hex_count++;
 					}
 				}

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -605,6 +605,10 @@ TEST(cmzn_scene, threejs_export_lines_cpp)
 
 	Materialmodule material_module = zinc.context.getMaterialmodule();
 	EXPECT_TRUE(material_module.isValid());
+	Spectrummodule spectrum_module = zinc.context.getSpectrummodule();
+	EXPECT_TRUE(spectrum_module.isValid());
+	Spectrum defaultSpectrum = spectrum_module.getDefaultSpectrum();
+	EXPECT_TRUE(defaultSpectrum.isValid());
 	Material material = material_module.createMaterial();
 	EXPECT_TRUE(material.isValid());
 	EXPECT_EQ(CMZN_OK, result =  material.setName("myyellow"));
@@ -624,6 +628,9 @@ TEST(cmzn_scene, threejs_export_lines_cpp)
 
 	EXPECT_EQ(CMZN_OK, result = lines.setCoordinateField(coordinateField));
 	EXPECT_EQ(CMZN_OK, result = lines.setMaterial(material));
+
+	EXPECT_EQ(CMZN_OK, result = lines.setDataField(coordinateField));
+	EXPECT_EQ(CMZN_OK, result = lines.setSpectrum(defaultSpectrum));
 
 	Graphicslineattributes lineAttr = lines.getGraphicslineattributes();
 	EXPECT_TRUE(lineAttr.isValid());
@@ -667,6 +674,9 @@ TEST(cmzn_scene, threejs_export_lines_cpp)
 	EXPECT_NE(static_cast<char *>(0), temp_char);
 
 	temp_char = strstr ( memory_buffer2, "faces");
+	EXPECT_NE(static_cast<char *>(0), temp_char);
+
+	temp_char = strstr ( memory_buffer2, "colors");
 	EXPECT_NE(static_cast<char *>(0), temp_char);
 
 	temp_char = strstr ( memory_buffer2, "materials");


### PR DESCRIPTION
Add colour exports on lines graphic.

The rendering of the resulting exports can be found here - https://mapcore-demo.org/current/scaffoldvuer/#/?url=https%3A%2F%2Fmapcore-bucket1.s3.us-west-2.amazonaws.com%2Fothers%2Fzincjs-testing-models%2FtimeExport_metadata.json