### PR TITLE
Fix conditional if field for non-real types

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v3.6.0
 Add material module change notifier.
 Add Sceneviewer enum to/from string name APIs. Serialise transparency layers.
 Add EX version 3 format supporting parameters with time sequence, node and element templates, compact group representation.
+Fix conditional if field non-real value type reporting and use in field assignment.
 
 v3.5.1
 Fix const usage in C++ API.

--- a/src/api/opencmiss/zinc/fieldassignment.h
+++ b/src/api/opencmiss/zinc/fieldassignment.h
@@ -23,7 +23,9 @@ extern "C" {
 
 /**
  * Create a field assignment object for assigning values of the target field,
- * from values of the source field.
+ * from values of the source field. Target and source fields must match in
+ * value type and number of components, and mesh location value type fields
+ * must be for the same host mesh.
  *
  * @param targetField  The target field to assign to.
  * @param sourceField  The source field to assign values from.

--- a/src/api/opencmiss/zinc/fieldconditional.h
+++ b/src/api/opencmiss/zinc/fieldconditional.h
@@ -24,7 +24,7 @@ extern "C" {
  * Creates a conditional field returning component values from source field two
  * if the condition source field one is true, otherwise source field three.
  * The field has the value type and number of components from source fields two
- * and three, which much match. Source fields two and three of mesh location
+ * and three, which must match. Source fields two and three of mesh location
  * value type must have matching host mesh.
  * For real value type, the condition field may be a vector of same length as
  * the other two source fields, in which case the condition is applied per-

--- a/src/api/opencmiss/zinc/fieldconditional.h
+++ b/src/api/opencmiss/zinc/fieldconditional.h
@@ -21,18 +21,25 @@ extern "C" {
 #endif
 
 /**
- * Creates a conditional field with the same number of components as each of the
- * source_fields. For each component, if the value of source_field_one is TRUE
- * (non-zero) then the result will be the value of source_field_two, otherwise the
- * component result will be taken from source_field_three.
+ * Creates a conditional field returning component values from source field two
+ * if the condition source field one is true, otherwise source field three.
+ * The field has the value type and number of components from source fields two
+ * and three, which much match. Source fields two and three of mesh location
+ * value type must have matching host mesh.
+ * For real value type, the condition field may be a vector of same length as
+ * the other two source fields, in which case the condition is applied per-
+ * component: a non-zero/true component gives the corresponding component value
+ * from source field two, zero/false gives the value from source field three.
  *
- * @param field_module  Region field module which will own new field.
- * @param source_field_one  Conditional field.
- * @param source_field_two  TRUE = non-zero conditional component results.
- * @param source_field_three  FALSE = zero conditional component results.
+ * @param fieldmodule  Region field module which will own new field.
+ * @param source_field_one  Condition field.
+ * @param source_field_two  Field components returned on true condition.
+ * Must have same value type and number of components as source_field_three.
+ * @param source_field_three  Field components returned on false condition.
+ * Must have same value type and number of components as source_field_two.
  * @return  Handle to new field, or NULL/invalid handle on failure.
  */
-ZINC_API cmzn_field_id cmzn_fieldmodule_create_field_if(cmzn_fieldmodule_id field_module,
+ZINC_API cmzn_field_id cmzn_fieldmodule_create_field_if(cmzn_fieldmodule_id fieldmodule,
 	cmzn_field_id source_field_one,
 	cmzn_field_id source_field_two,
 	cmzn_field_id source_field_three);

--- a/src/computed_field/computed_field_finite_element.cpp
+++ b/src/computed_field/computed_field_finite_element.cpp
@@ -4556,9 +4556,9 @@ char *cmzn_field_edge_discontinuity_measure_enum_to_string(
 	return (measure_string ? duplicate_string(measure_string) : 0);
 }
 
-FE_mesh *cmzn_field_get_host_FE_mesh(cmzn_field_id field)
+FE_mesh *cmzn_field_get_host_FE_mesh(cmzn_field *field)
 {
-	if (field && field->core && (CMZN_FIELD_VALUE_TYPE_MESH_LOCATION == cmzn_field_get_value_type(field)))
+	if (field && field->core && (field->getValueType() == CMZN_FIELD_VALUE_TYPE_MESH_LOCATION))
 	{
 		Computed_field_finite_element *fieldFiniteElement = dynamic_cast<Computed_field_finite_element*>(field->core);
 		if (fieldFiniteElement)
@@ -4570,59 +4570,17 @@ FE_mesh *cmzn_field_get_host_FE_mesh(cmzn_field_id field)
 		{
 			return cmzn_mesh_get_FE_mesh_internal(fieldFindMeshLocation->getMesh());
 		}
+		// for other fields, e.g. conditional field if, use first source field host mesh
+		for (int i = 0; i < field->number_of_source_fields; ++i)
+		{
+			if (field->source_fields[i]->getValueType() == CMZN_FIELD_VALUE_TYPE_MESH_LOCATION)
+			{
+				return cmzn_field_get_host_FE_mesh(field->source_fields[i]);
+			}
+		}
 	}
 	display_message(ERROR_MESSAGE, "cmzn_field_get_host_FE_mesh.  Invalid argument(s)");
 	return nullptr;
-}
-
-int cmzn_field_discover_element_xi_host_mesh_from_source(cmzn_field *destination_field, cmzn_field * source_field)
-{
-	if (!((destination_field) && (source_field)
-		&& (cmzn_field_get_value_type(destination_field) == CMZN_FIELD_VALUE_TYPE_MESH_LOCATION)
-		&& (cmzn_field_get_value_type(source_field) == CMZN_FIELD_VALUE_TYPE_MESH_LOCATION)))
-	{
-		display_message(ERROR_MESSAGE, "cmzn_field_discover_element_xi_host_mesh_from_source.  Invalid argument(s)");
-		return CMZN_ERROR_ARGUMENT;
-	}
-	FE_mesh *source_fe_mesh = cmzn_field_get_host_FE_mesh(source_field);
-	if (!source_fe_mesh)
-	{
-		display_message(ERROR_MESSAGE, "cmzn_field_discover_element_xi_host_mesh_from_source.  Source field does not have a host mesh");
-		return CMZN_ERROR_ARGUMENT;
-	}
-	FE_mesh *destination_fe_mesh = cmzn_field_get_host_FE_mesh(destination_field);
-	if (destination_fe_mesh != source_fe_mesh)
-	{
-		if (!destination_fe_mesh)
-		{
-			FE_field *destination_fe_field = 0;
-			Computed_field_get_type_finite_element(destination_field, &destination_fe_field);
-			if (!destination_fe_field)
-			{
-				display_message(ERROR_MESSAGE, "cmzn_field_discover_element_xi_host_mesh_from_source.  "
-					"Destination is not a stored mesh location field");
-				return CMZN_ERROR_ARGUMENT;
-			}
-			if (CMZN_OK == destination_fe_field->setElementXiHostMesh(source_fe_mesh))
-			{
-				display_message(WARNING_MESSAGE, "Discovered host mesh '%s' for element_xi / stored mesh location field '%s'. Should be explicitly set.",
-					source_fe_mesh->getName(), destination_field->name);
-			}
-			else
-			{
-				display_message(ERROR_MESSAGE, "cmzn_field_discover_element_xi_host_mesh_from_source.  "
-					"Failed to set destination host mesh");
-				return CMZN_ERROR_ARGUMENT;
-			}
-		}
-		else
-		{
-			display_message(ERROR_MESSAGE, "cmzn_field_discover_element_xi_host_mesh_from_source.  "
-				"Source and destination fields have different host meshes");
-			return CMZN_ERROR_ARGUMENT;
-		}
-	}
-	return CMZN_OK;
 }
 
 FE_element_field_evaluation *cmzn_field_get_cache_FE_element_field_evaluation(cmzn_field *field, cmzn_fieldcache *fieldcache)

--- a/src/computed_field/computed_field_finite_element.h
+++ b/src/computed_field/computed_field_finite_element.h
@@ -180,11 +180,7 @@ char *cmzn_field_edge_discontinuity_measure_enum_to_string(
 	enum cmzn_field_edge_discontinuity_measure measure);
 
 /** @return  Host mesh for find or stored mesh location fields. For time being must check if none. */
-FE_mesh *cmzn_field_get_host_FE_mesh(cmzn_field_id field);
-
-/** Discover and set destination host mesh from source field, or check it matches if already set.
-  * @return  Result OK on success, any other value on failure. */
-int cmzn_field_discover_element_xi_host_mesh_from_source(cmzn_field *destination_field, cmzn_field * source_field);
+FE_mesh *cmzn_field_get_host_FE_mesh(cmzn_field *field);
 
 class FE_element_field_evaluation;
 

--- a/src/computed_field/computed_field_update.cpp
+++ b/src/computed_field/computed_field_update.cpp
@@ -42,13 +42,11 @@ int cmzn_nodeset_assign_field_from_source(
 		cmzn_field_value_type value_type = cmzn_field_get_value_type(destination_field);
 		if (value_type == CMZN_FIELD_VALUE_TYPE_MESH_LOCATION)
 		{
-			// element_xi fields used to allow locations in multiple meshes, but are now
-			// restricted to a single host mesh. This must be discovered if necessary.
-			// This only happens when read from legacy EX format or created in Cmgui.
-			const int result = cmzn_field_discover_element_xi_host_mesh_from_source(destination_field, source_field);
-			if (CMZN_OK != result)
+			if (cmzn_field_get_host_FE_mesh(destination_field) != cmzn_field_get_host_FE_mesh(source_field))
 			{
-				return result;
+				display_message(ERROR_MESSAGE, "Field assignment:  "
+					"destination and source fields have mesh location values in different host meshes");
+				return CMZN_ERROR_ARGUMENT;
 			}
 		}
 		const int componentCount = cmzn_field_get_number_of_components(destination_field);

--- a/src/computed_field/fieldassignmentprivate.cpp
+++ b/src/computed_field/fieldassignmentprivate.cpp
@@ -15,6 +15,7 @@
 #include "opencmiss/zinc/nodeset.h"
 #include "computed_field/fieldassignmentprivate.hpp"
 #include "computed_field/computed_field.h"
+#include "computed_field/computed_field_finite_element.h"
 #include "computed_field/computed_field_update.h"
 #include "mesh/cmiss_node_private.hpp"
 #include "general/debug.h"
@@ -41,7 +42,9 @@ cmzn_fieldassignment *cmzn_fieldassignment::create(cmzn_field *targetFieldIn, cm
 	if ((Computed_field_get_region(sourceFieldIn) == Computed_field_get_region(targetFieldIn))
 		&& (cmzn_field_get_value_type(sourceFieldIn) == cmzn_field_get_value_type(targetFieldIn))
 		&& (cmzn_field_get_number_of_components(sourceFieldIn)
-			== cmzn_field_get_number_of_components(targetFieldIn)))
+			== cmzn_field_get_number_of_components(targetFieldIn))
+		&& ((cmzn_field_get_value_type(sourceFieldIn) != CMZN_FIELD_VALUE_TYPE_MESH_LOCATION)
+			|| (cmzn_field_get_host_FE_mesh(sourceFieldIn) == cmzn_field_get_host_FE_mesh(targetFieldIn))))
 	{
 		return new cmzn_fieldassignment(targetFieldIn, sourceFieldIn);
 	}

--- a/src/finite_element/finite_element_field.hpp
+++ b/src/finite_element/finite_element_field.hpp
@@ -434,8 +434,9 @@ PROTOTYPE_CHANGE_LOG_FUNCTIONS(FE_field);
  * from <field_list>. Returns 1 (true) if there is either no such field in the
  * list or the two fields return true for FE_fields::compareBasicDefinition(),
  * otherwise returns 0 (false).
+ * Also returns 0 if field has mesh location value type but no host mesh.
  */
-int FE_field_can_be_merged_into_list(struct FE_field *field, void *field_list_void);
+int FE_field_can_be_merged(struct FE_field *field, void *field_list_void);
 
 /**
  * Return true if any basis functions used by the field is non-linear i.e.

--- a/src/finite_element/finite_element_region.cpp
+++ b/src/finite_element/finite_element_region.cpp
@@ -1199,7 +1199,7 @@ bool FE_region_can_merge(struct FE_region *target_fe_region,
 	if (target_fe_region)
 	{
 		// check fields of the same name have compatible definitions
-		if (!FOR_EACH_OBJECT_IN_LIST(FE_field)(FE_field_can_be_merged_into_list,
+		if (!FOR_EACH_OBJECT_IN_LIST(FE_field)(FE_field_can_be_merged,
 			(void *)target_fe_region->fe_field_list, source_fe_region->fe_field_list))
 		{
 			display_message(ERROR_MESSAGE,

--- a/src/finite_element/import_finite_element.cpp
+++ b/src/finite_element/import_finite_element.cpp
@@ -994,7 +994,7 @@ bool EXReader::readElementXiValue(FE_field *field, cmzn_element* &element, FE_va
 		display_message(ERROR_MESSAGE, "EXReader::readElementXiValue.  Invalid argument(s)");
 		return false;
 	}
-	// const_cast is dirty, but mesh is constant as far as field is concerned,
+	// mesh is constant as far as field is concerned,
 	// however this function can create blank elements in mesh
 	FE_mesh *hostMesh = field->getElementXiHostMesh();
 	DsLabelIdentifier elementIdentifier;

--- a/tests/fieldmodule/fieldconditional.cpp
+++ b/tests/fieldmodule/fieldconditional.cpp
@@ -1,0 +1,185 @@
+/*
+ * OpenCMISS-Zinc Library Unit Tests
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <gtest/gtest.h>
+
+#include <opencmiss/zinc/field.hpp>
+#include <opencmiss/zinc/fieldassignment.hpp>
+#include <opencmiss/zinc/fieldcache.hpp>
+#include <opencmiss/zinc/fieldconditional.hpp>
+#include <opencmiss/zinc/fieldconstant.hpp>
+#include <opencmiss/zinc/fieldfiniteelement.hpp>
+#include <opencmiss/zinc/fieldlogicaloperators.hpp>
+#include <opencmiss/zinc/fieldsubobjectgroup.hpp>
+
+#include "zinctestsetupcpp.hpp"
+#include "test_resources.h"
+
+// Issue 214: FieldIf should report value type of source fields 2, 3. Mesh location case.
+TEST(ZincFieldIf, valueTypeMeshLocation)
+{
+	ZincTestSetupCpp zinc;
+
+	// a handy model with nodes 1-4 in the corners of a square and nodes 5-8 with host locations
+	EXPECT_EQ(RESULT_OK, zinc.root_region.readFile(TestResources::getLocation(
+		TestResources::FIELDMODULE_EMBEDDING_ISSUE3614_RESOURCE)));
+
+	Mesh mesh2d = zinc.fm.findMeshByDimension(2);
+	EXPECT_TRUE(mesh2d.isValid());
+	Field coordinates = zinc.fm.findFieldByName("coordinates");
+	EXPECT_TRUE(coordinates.isValid());
+	Field dataCoordinates = zinc.fm.findFieldByName("data_coordinates");
+	EXPECT_TRUE(dataCoordinates.isValid());
+	Field hostLocation = zinc.fm.findFieldByName("host_location");
+	EXPECT_TRUE(hostLocation.isValid());
+	EXPECT_EQ(Field::VALUE_TYPE_MESH_LOCATION, hostLocation.getValueType());
+
+	FieldFindMeshLocation findHostLocation = zinc.fm.createFieldFindMeshLocation(dataCoordinates, coordinates, mesh2d);
+	EXPECT_EQ(RESULT_OK, findHostLocation.setSearchMode(FieldFindMeshLocation::SEARCH_MODE_NEAREST));
+	EXPECT_EQ(Field::VALUE_TYPE_MESH_LOCATION, findHostLocation.getValueType());
+	FieldIsDefined hasDataCoordinates = zinc.fm.createFieldIsDefined(dataCoordinates);
+	EXPECT_TRUE(hasDataCoordinates.isValid());
+
+	FieldIf conditionalHostLocation = zinc.fm.createFieldIf(hasDataCoordinates, findHostLocation, hostLocation);
+	EXPECT_TRUE(conditionalHostLocation.isValid());
+	EXPECT_EQ(Field::VALUE_TYPE_MESH_LOCATION, conditionalHostLocation.getValueType());
+
+	Element element1 = mesh2d.findElementByIdentifier(1);
+	EXPECT_TRUE(element1.isValid());
+
+	const double expectedFindXi[4][2] = {
+		{ 0.12, 0.10 },
+		{ 0.76, 0.20 },
+		{ 0.92, 0.80 },
+		{ 0.31, 0.80 }
+	};
+	const double expectedXi[4][2] = {
+		{ 0.10, 0.10 },
+		{ 0.75, 0.25 },
+		{ 0.90, 0.75 },
+		{ 0.33, 0.90 }
+	};
+	Nodeset nodes = zinc.fm.findNodesetByFieldDomainType(Field::DOMAIN_TYPE_NODES);
+	EXPECT_TRUE(nodes.isValid());
+	Fieldcache fieldcache = zinc.fm.createFieldcache();
+	Element element;
+	double xi[2];
+	const double TOL = 1.0E-9;
+	for (int n = 0; n < 4; ++n)
+	{
+		Node node = nodes.findNodeByIdentifier(n + 5);
+		EXPECT_TRUE(node.isValid());
+		EXPECT_EQ(RESULT_OK, fieldcache.setNode(node));
+		element = conditionalHostLocation.evaluateMeshLocation(fieldcache, 2, xi);
+		EXPECT_EQ(element1, element);
+		for (int c = 0; c < 2; ++c)
+			EXPECT_NEAR(expectedFindXi[n][c], xi[c], TOL);
+		element = findHostLocation.evaluateMeshLocation(fieldcache, 2, xi);
+		EXPECT_EQ(element1, element);
+		for (int c = 0; c < 2; ++c)
+			EXPECT_NEAR(expectedFindXi[n][c], xi[c], TOL);
+		element = hostLocation.evaluateMeshLocation(fieldcache, 2, xi);
+		EXPECT_EQ(element1, element);
+		for (int c = 0; c < 2; ++c)
+			EXPECT_DOUBLE_EQ(expectedXi[n][c], xi[c]);
+	}
+
+	// test field assignment works:
+	Fieldassignment fieldassignment = hostLocation.createFieldassignment(conditionalHostLocation);
+	EXPECT_TRUE(fieldassignment.isValid());
+	// only defined on nodes 5-8:
+	EXPECT_EQ(RESULT_WARNING_PART_DONE, fieldassignment.assign());
+	for (int n = 0; n < 4; ++n)
+	{
+		Node node = nodes.findNodeByIdentifier(n + 5);
+		EXPECT_TRUE(node.isValid());
+		EXPECT_EQ(RESULT_OK, fieldcache.setNode(node));
+		element = hostLocation.evaluateMeshLocation(fieldcache, 2, xi);
+		EXPECT_EQ(element1, element);
+		for (int c = 0; c < 2; ++c)
+			EXPECT_NEAR(expectedFindXi[n][c], xi[c], TOL);
+	}
+}
+
+// Test can't create FieldIf for source fields with different host meshes
+TEST(ZincFieldIf, valueTypeMeshLocationDifferentHostMesh)
+{
+	ZincTestSetupCpp zinc;
+
+	Mesh mesh2d = zinc.fm.findMeshByDimension(2);
+	EXPECT_TRUE(mesh2d.isValid());
+	Mesh mesh3d = zinc.fm.findMeshByDimension(3);
+	EXPECT_TRUE(mesh3d.isValid());
+
+	FieldStoredMeshLocation meshLocation2d = zinc.fm.createFieldStoredMeshLocation(mesh2d);
+	EXPECT_TRUE(meshLocation2d.isValid());
+	FieldStoredMeshLocation meshLocation3d = zinc.fm.createFieldStoredMeshLocation(mesh3d);
+	EXPECT_TRUE(meshLocation3d.isValid());
+	const double constOne = 1.0;
+	FieldConstant one = zinc.fm.createFieldConstant(1, &constOne);
+	EXPECT_TRUE(one.isValid());
+
+	FieldIf conditionalMeshLocation = zinc.fm.createFieldIf(one, meshLocation2d, meshLocation3d);
+	EXPECT_FALSE(conditionalMeshLocation.isValid());
+	conditionalMeshLocation = zinc.fm.createFieldIf(one, meshLocation2d, meshLocation2d);
+	EXPECT_TRUE(conditionalMeshLocation.isValid());
+	conditionalMeshLocation = zinc.fm.createFieldIf(one, meshLocation3d, meshLocation3d);
+	EXPECT_TRUE(conditionalMeshLocation.isValid());
+
+	// test can't make field assignment with different host meshes:
+	Fieldassignment fieldassignment = meshLocation3d.createFieldassignment(meshLocation2d);
+	EXPECT_FALSE(fieldassignment.isValid());
+}
+
+// Issue 214: FieldIf should report value type of source fields 2, 3. String case.
+TEST(ZincFieldIf, valueTypeString)
+{
+	ZincTestSetupCpp zinc;
+
+	FieldStringConstant constantString = zinc.fm.createFieldStringConstant("fred");
+	EXPECT_TRUE(constantString.isValid());
+	EXPECT_EQ(Field::VALUE_TYPE_STRING, constantString.getValueType());
+	FieldStoredString storedString = zinc.fm.createFieldStoredString();
+	EXPECT_TRUE(storedString.isValid());
+	EXPECT_EQ(Field::VALUE_TYPE_STRING, storedString.getValueType());
+
+	Nodeset nodes = zinc.fm.findNodesetByFieldDomainType(Field::DOMAIN_TYPE_NODES);
+	EXPECT_TRUE(nodes.isValid());
+	Nodetemplate nodetemplate = nodes.createNodetemplate();
+	EXPECT_TRUE(nodetemplate.isValid());
+	EXPECT_EQ(RESULT_OK, nodetemplate.defineField(storedString));
+
+	Node node1 = nodes.createNode(1, nodetemplate);
+	EXPECT_TRUE(node1.isValid());
+	Fieldcache fieldcache = zinc.fm.createFieldcache();
+	EXPECT_EQ(RESULT_OK, fieldcache.setNode(node1));
+	EXPECT_EQ(RESULT_OK, storedString.assignString(fieldcache, "bob"));
+
+	const double constOne = 1.0;
+	FieldConstant one = zinc.fm.createFieldConstant(1, &constOne);
+	FieldIf conditionalString = zinc.fm.createFieldIf(one, storedString, constantString);
+	EXPECT_TRUE(conditionalString.isValid());
+	EXPECT_EQ(Field::VALUE_TYPE_STRING, conditionalString.getValueType());
+
+	// reset field cache and evaluate fields
+	fieldcache = zinc.fm.createFieldcache();
+	EXPECT_EQ(RESULT_OK, fieldcache.setNode(node1));
+	EXPECT_STREQ("bob", storedString.evaluateString(fieldcache));
+	EXPECT_STREQ("bob", conditionalString.evaluateString(fieldcache));
+	EXPECT_STREQ("fred", constantString.evaluateString(fieldcache));
+
+	// test field assignment works:
+	Fieldassignment fieldassignment = storedString.createFieldassignment(constantString);
+	EXPECT_TRUE(fieldassignment.isValid());
+	EXPECT_EQ(RESULT_OK, fieldassignment.assign());
+	EXPECT_EQ(RESULT_OK, constantString.assignString(fieldcache, "bob"));
+
+	EXPECT_STREQ("fred", storedString.evaluateString(fieldcache));
+	EXPECT_STREQ("fred", conditionalString.evaluateString(fieldcache));
+	EXPECT_STREQ("bob", constantString.evaluateString(fieldcache));
+}

--- a/tests/fieldmodule/tests.cmake
+++ b/tests/fieldmodule/tests.cmake
@@ -19,6 +19,7 @@ SET(${CURRENT_TEST}_SRC
 	${CURRENT_TEST}/fieldapply.cpp
 	${CURRENT_TEST}/fieldarithmeticoperators.cpp
 	${CURRENT_TEST}/fieldassignment.cpp
+	${CURRENT_TEST}/fieldconditional.cpp
 	${CURRENT_TEST}/fieldconstant.cpp
 	${CURRENT_TEST}/fieldimage.cpp
 	${CURRENT_TEST}/fielditerator.cpp


### PR DESCRIPTION
Fix field assignment for mesh location fields. Guarantee FE_field host mesh is set (except temporarily when reading legacy EX files).

Fixes #214.