### PR TITLE
Add test for single element line export to webGL.

### DIFF
--- a/src/graphics/threejs_export.cpp
+++ b/src/graphics/threejs_export.cpp
@@ -1212,7 +1212,7 @@ void Threejs_export_point::writeIndexBufferWithoutIndex(int typeMask, int number
 		facesString += "\t\"faces\": [\n";
 		unsigned int number_of_triangles = number_of_points / 3;
 		int current_index = 0;
-		for (unsigned i = 0; i < number_of_triangles; i++)
+        for (unsigned i = 0; i < number_of_triangles; i++)
 		{
 			sprintf(temp,"\t\t%d", typeMask);
 			facesString += temp;
@@ -1234,7 +1234,9 @@ void Threejs_export_point::writeIndexBufferWithoutIndex(int typeMask, int number
 		unsigned int unused_points =  number_of_points - number_of_triangles * 3;
 		if (unused_points > 0)
 		{
-			facesString += ",";
+            if (number_of_triangles > 0) {
+                facesString += ",";
+            }
 			sprintf(temp,"\t\t%d", typeMask);
 			facesString += temp;
 			if (unused_points == 1)

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -1837,9 +1837,6 @@ TEST(cmzn_scene, threejs_export_simple_line_cpp)
     result = memory_sr2.getBuffer((const void**)&memory_buffer2, &size);
     EXPECT_EQ(CMZN_OK, result);
 
-    std::cout << "buffer" << std::endl;
-    std::cout << memory_buffer2 << std::endl;
-
     temp_char = strstr ( memory_buffer2, "vertices");
     EXPECT_NE(static_cast<char *>(0), temp_char);
 

--- a/tests/graphics/scene.cpp
+++ b/tests/graphics/scene.cpp
@@ -1763,3 +1763,92 @@ TEST(cmzn_scene, wavefront_export_text)
     temp_char = strstr(memory_buffer, "f 21 22 23");
     EXPECT_NE(static_cast<char *>(0), temp_char);
 }
+
+TEST(cmzn_scene, threejs_export_simple_line_cpp)
+{
+    ZincTestSetupCpp zinc;
+
+    int result;
+
+    Materialmodule material_module = zinc.context.getMaterialmodule();
+    EXPECT_TRUE(material_module.isValid());
+    Spectrummodule spectrum_module = zinc.context.getSpectrummodule();
+    EXPECT_TRUE(spectrum_module.isValid());
+    Spectrum defaultSpectrum = spectrum_module.getDefaultSpectrum();
+    EXPECT_TRUE(defaultSpectrum.isValid());
+    Material material = material_module.createMaterial();
+    EXPECT_TRUE(material.isValid());
+    EXPECT_EQ(CMZN_OK, result =  material.setName("myyellow"));
+    EXPECT_EQ(CMZN_OK, result =  material.setManaged(true));
+    double double_value[3] = {0.9, 0.9, 0.0};
+
+    EXPECT_EQ(CMZN_OK, result =  material.setAttributeReal3(Material::ATTRIBUTE_AMBIENT, double_value));
+    EXPECT_EQ(CMZN_OK, result =  material.setAttributeReal3(Material::ATTRIBUTE_DIFFUSE, double_value));
+
+    EXPECT_EQ(CMZN_OK, result = zinc.root_region.readFile(resourcePath("fieldmodule/simple_1d_element.exf").c_str()));
+
+    GraphicsLines lines = zinc.scene.createGraphicsLines();
+    EXPECT_TRUE(lines.isValid());
+
+    Field coordinateField = zinc.fm.findFieldByName("coordinates");
+    EXPECT_TRUE(coordinateField.isValid());
+
+    EXPECT_EQ(CMZN_OK, result = lines.setCoordinateField(coordinateField));
+    EXPECT_EQ(CMZN_OK, result = lines.setMaterial(material));
+
+    EXPECT_EQ(CMZN_OK, result = lines.setDataField(coordinateField));
+    EXPECT_EQ(CMZN_OK, result = lines.setSpectrum(defaultSpectrum));
+
+    Graphicslineattributes lineAttr = lines.getGraphicslineattributes();
+    EXPECT_TRUE(lineAttr.isValid());
+
+    EXPECT_EQ(CMZN_OK, result = lineAttr.setShapeType(lineAttr.ShapeType::SHAPE_TYPE_LINE ));
+
+    StreaminformationScene si = zinc.scene.createStreaminformationScene();
+    EXPECT_TRUE(si.isValid());
+
+    EXPECT_EQ(CMZN_OK, result = si.setIOFormat(si.IO_FORMAT_THREEJS));
+
+    EXPECT_EQ(2, result = si.getNumberOfResourcesRequired());
+
+    EXPECT_EQ(0, result = si.getNumberOfTimeSteps());
+
+    double double_result = 0.0;
+    EXPECT_EQ(0.0, double_result = si.getInitialTime());
+    EXPECT_EQ(0.0, double_result = si.getFinishTime());
+
+    StreamresourceMemory memory_sr = si.createStreamresourceMemory();
+    StreamresourceMemory memory_sr2 = si.createStreamresourceMemory();
+
+    EXPECT_EQ(CMZN_OK, result = zinc.scene.write(si));
+
+    char *memory_buffer = nullptr, *memory_buffer2 = nullptr;
+    unsigned int size = 0;
+
+    result = memory_sr.getBuffer((const void**)&memory_buffer, &size);
+    EXPECT_EQ(CMZN_OK, result);
+
+    char *temp_char = strstr ( memory_buffer, "Lines");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+
+    temp_char = strstr ( memory_buffer, "MorphVertices");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+
+    result = memory_sr2.getBuffer((const void**)&memory_buffer2, &size);
+    EXPECT_EQ(CMZN_OK, result);
+
+    std::cout << "buffer" << std::endl;
+    std::cout << memory_buffer2 << std::endl;
+
+    temp_char = strstr ( memory_buffer2, "vertices");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+
+    temp_char = strstr ( memory_buffer2, "faces");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+
+    temp_char = strstr ( memory_buffer2, "colors");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+
+    temp_char = strstr ( memory_buffer2, "materials");
+    EXPECT_NE(static_cast<char *>(0), temp_char);
+}

--- a/tests/resources/fieldmodule/simple_1d_element.exf
+++ b/tests/resources/fieldmodule/simple_1d_element.exf
@@ -1,0 +1,56 @@
+EX Version: 3
+Region: /
+!#nodeset nodes
+Define node template: node1
+Shape. Dimension=0
+#Fields=1
+1) coordinates, coordinate, rectangular cartesian, real, #Components=3
+ x. #Values=1 (value)
+ y. #Values=1 (value)
+ z. #Values=1 (value)
+Node template: node1
+Node: 1457
+  3.736439895629883e+01
+ -2.124891204833984e+02
+  1.020281555175781e+03
+Node: 1435
+  1.220113067626953e+02
+ -6.937643432617188e+01
+  1.124542358398438e+03
+!#mesh mesh1d, dimension=1, nodeset=nodes
+Define element template: element1
+Shape. Dimension=1, line
+#Scale factor sets=0
+#Nodes=2
+#Fields=1
+1) coordinates, coordinate, rectangular cartesian, real, #Components=3
+ x. l.Lagrange, no modify, standard node based.
+  #Nodes=2
+  1. #Values=1
+   Value labels: value
+  2. #Values=1
+   Value labels: value
+ y. l.Lagrange, no modify, standard node based.
+  #Nodes=2
+  1. #Values=1
+   Value labels: value
+  2. #Values=1
+   Value labels: value
+ z. l.Lagrange, no modify, standard node based.
+  #Nodes=2
+  1. #Values=1
+   Value labels: value
+  2. #Values=1
+   Value labels: value
+Element template: element1
+Element: 1211
+ Nodes:
+ 1435 1457
+Group name: Anterior branch of lateral cutaneous branch of left eighth intercostal nerve
+!#nodeset nodes
+Node group:
+1435,1457
+!#mesh mesh1d, dimension=1, nodeset=nodes
+Element group:
+1211
+


### PR DESCRIPTION
I think this might be the actual issue with exporting webGL lines. It is not related to tessellations as originally thought.

Addresses #286.